### PR TITLE
Add bz2 as an available PHP7 extension. Required for Acquia BLT.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     php7.0-xdebug \
     php7.0-xml \
     php7.0-zip \
+    php7.0-bz2 \
     # Cleanup
     && DEBIAN_FRONTEND=noninteractive apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Adds the bz2 PHP7 extension so the latest version of Acquia BLT installs cleanly.