### PR TITLE
Add hirak/prestissimo composer plugin to speed up package installation. Fixes #14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -243,6 +243,8 @@ RUN \
     # Drupal Coder w/ a matching version of PHP_CodeSniffer
     composer global require drupal/coder && \
     phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer && \
+    # Composer parallel install plugin
+    composer global require hirak/prestissimo && \
     # Cleanup
     composer clear-cache
 


### PR DESCRIPTION
Requested in https://github.com/docksal/service-cli/issues/14

Speeds up installation of composer packages by running requests in parallel see https://github.com/hirak/prestissimo