### PR TITLE
Include mhsendmail binary

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,4 +1,4 @@
-#Build mhsendmail
+# Build mhsendmail
 FROM golang:1.8.3 as mhbuild
 ENV MHSENDMAIL_VERSION=0.2.0
 RUN set -xe; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,3 +1,12 @@
+#Build mhsendmail
+FROM golang:1.8.3 as mhbuild
+ENV MHSENDMAIL_VERSION=0.2.0
+RUN set -xe; \
+  go get -d github.com/mailhog/mhsendmail; \
+  cd /go/src/github.com/mailhog/mhsendmail; \
+	git checkout tags/v${MHSENDMAIL_VERSION}; \
+	go get github.com/mailhog/mhsendmail
+
 FROM php:5-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -185,10 +194,12 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Copy mhsendmail binary from stage 1
+COPY --from=mhbuild /go/bin/mhsendmail /usr/local/bin/mhsendmail
+
 ENV COMPOSER_VERSION=1.5.2 \
 	DRUSH_VERSION=8.1.13 \
 	DRUPAL_CONSOLE_VERSION=1.0.2 \
-	MHSENDMAIL_VERSION=0.2.0 \
 	WPCLI_VERSION=1.3.0 \
 	MG_CODEGEN_VERSION=1.6.4 \
 	BLACKFIRE_VERSION=1.14.1
@@ -199,8 +210,6 @@ RUN set -xe; \
 	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
 	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
-	# mhsendmail for MailHog integration
-	curl -sSL "https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64" -o /usr/local/bin/mhsendmail; \
 	# Install wp-cli
 	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Install magento code generator

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -4,8 +4,8 @@ ENV MHSENDMAIL_VERSION=0.2.0
 RUN set -xe; \
   go get -d github.com/mailhog/mhsendmail; \
   cd /go/src/github.com/mailhog/mhsendmail; \
-	git checkout tags/v${MHSENDMAIL_VERSION}; \
-	go get github.com/mailhog/mhsendmail
+  git checkout tags/v${MHSENDMAIL_VERSION}; \
+  go get github.com/mailhog/mhsendmail
 
 FROM php:5-fpm
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -1,3 +1,12 @@
+#Build mhsendmail
+FROM golang:1.8.3 as mhbuild
+ENV MHSENDMAIL_VERSION=0.2.0
+RUN set -xe; \
+  go get -d github.com/mailhog/mhsendmail; \
+  cd /go/src/github.com/mailhog/mhsendmail; \
+	git checkout tags/v${MHSENDMAIL_VERSION}; \
+	go get github.com/mailhog/mhsendmail
+
 FROM php:7.0-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -189,10 +198,12 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Copy mhsendmail binary from stage 1
+COPY --from=mhbuild /go/bin/mhsendmail /usr/local/bin/mhsendmail
+
 ENV COMPOSER_VERSION=1.5.2 \
 	DRUSH_VERSION=8.1.13 \
 	DRUPAL_CONSOLE_VERSION=1.0.2 \
-	MHSENDMAIL_VERSION=0.2.0 \
 	WPCLI_VERSION=1.3.0 \
 	MG_CODEGEN_VERSION=1.6.4 \
 	BLACKFIRE_VERSION=1.14.1
@@ -203,8 +214,6 @@ RUN set -xe; \
 	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
 	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
-	# mhsendmail for MailHog integration
-	curl -sSL "https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64" -o /usr/local/bin/mhsendmail; \
 	# Install wp-cli
 	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Install magento code generator

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -4,8 +4,8 @@ ENV MHSENDMAIL_VERSION=0.2.0
 RUN set -xe; \
   go get -d github.com/mailhog/mhsendmail; \
   cd /go/src/github.com/mailhog/mhsendmail; \
-	git checkout tags/v${MHSENDMAIL_VERSION}; \
-	go get github.com/mailhog/mhsendmail
+  git checkout tags/v${MHSENDMAIL_VERSION}; \
+  go get github.com/mailhog/mhsendmail
 
 FROM php:7.0-fpm
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,3 +1,12 @@
+#Build mhsendmail
+FROM golang:1.8.3 as mhbuild
+ENV MHSENDMAIL_VERSION=0.2.0
+RUN set -xe; \
+  go get -d github.com/mailhog/mhsendmail; \
+  cd /go/src/github.com/mailhog/mhsendmail; \
+	git checkout tags/v${MHSENDMAIL_VERSION}; \
+	go get github.com/mailhog/mhsendmail
+
 FROM php:7.1-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -189,10 +198,12 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Copy mhsendmail binary from stage 1
+COPY --from=mhbuild /go/bin/mhsendmail /usr/local/bin/mhsendmail
+
 ENV COMPOSER_VERSION=1.5.2 \
 	DRUSH_VERSION=8.1.13 \
 	DRUPAL_CONSOLE_VERSION=1.0.2 \
-	MHSENDMAIL_VERSION=0.2.0 \
 	WPCLI_VERSION=1.3.0 \
 	MG_CODEGEN_VERSION=1.6.4 \
 	BLACKFIRE_VERSION=1.14.1
@@ -203,8 +214,6 @@ RUN set -xe; \
 	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
 	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
-	# mhsendmail for MailHog integration
-	curl -sSL "https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64" -o /usr/local/bin/mhsendmail; \
 	# Install wp-cli
 	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Install magento code generator

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -4,8 +4,8 @@ ENV MHSENDMAIL_VERSION=0.2.0
 RUN set -xe; \
   go get -d github.com/mailhog/mhsendmail; \
   cd /go/src/github.com/mailhog/mhsendmail; \
-	git checkout tags/v${MHSENDMAIL_VERSION}; \
-	go get github.com/mailhog/mhsendmail
+  git checkout tags/v${MHSENDMAIL_VERSION}; \
+  go get github.com/mailhog/mhsendmail
 
 FROM php:7.1-fpm
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -4,8 +4,8 @@ ENV MHSENDMAIL_VERSION=0.2.0
 RUN set -xe; \
   go get -d github.com/mailhog/mhsendmail; \
   cd /go/src/github.com/mailhog/mhsendmail; \
-	git checkout tags/v${MHSENDMAIL_VERSION}; \
-	go get github.com/mailhog/mhsendmail
+  git checkout tags/v${MHSENDMAIL_VERSION}; \
+  go get github.com/mailhog/mhsendmail
 
 FROM php:7.2-fpm
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,3 +1,12 @@
+#Build mhsendmail
+FROM golang:1.8.3 as mhbuild
+ENV MHSENDMAIL_VERSION=0.2.0
+RUN set -xe; \
+  go get -d github.com/mailhog/mhsendmail; \
+  cd /go/src/github.com/mailhog/mhsendmail; \
+	git checkout tags/v${MHSENDMAIL_VERSION}; \
+	go get github.com/mailhog/mhsendmail
+
 FROM php:7.2-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -192,10 +201,12 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Copy mhsendmail binary from stage 1
+COPY --from=mhbuild /go/bin/mhsendmail /usr/local/bin/mhsendmail
+
 ENV COMPOSER_VERSION=1.5.2 \
 	DRUSH_VERSION=8.1.13 \
 	DRUPAL_CONSOLE_VERSION=1.0.2 \
-	MHSENDMAIL_VERSION=0.2.0 \
 	WPCLI_VERSION=1.3.0 \
 	MG_CODEGEN_VERSION=1.6.4 \
 	BLACKFIRE_VERSION=1.14.1
@@ -206,8 +217,6 @@ RUN set -xe; \
 	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
 	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
-	# mhsendmail for MailHog integration
-	curl -sSL "https://github.com/mailhog/mhsendmail/releases/download/v${MHSENDMAIL_VERSION}/mhsendmail_linux_amd64" -o /usr/local/bin/mhsendmail; \
 	# Install wp-cli
 	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Install magento code generator


### PR DESCRIPTION
https://github.com/docksal/docksal/issues/416

The official release sendmail binary is compiled with a version of Go <1.8 which means it doesn't respect the resolvconf option `options ndots:0` when performing DNS lookups.
https://groups.google.com/forum/#!msg/golang-codereviews/aSIWRSuuwDE/hRvAKeoHAwAJ

Here, I've compiled mhsendmail v0.2.0 using golang v1.8.3 and included it in-repo. Dockerfile is modified to copy this binary in rather than curl it from the official release site.

Perhaps a binary shouldn't be in a repo, but preferable to making golang a requirement for building this image?