### PR TITLE
Upgrade Git to get composer git cache

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -37,6 +37,8 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
+	# Include backports
+	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# Include blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -54,7 +54,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		dnsutils \
-		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -78,6 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
+    # More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -77,8 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
-    # More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
+	# More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -37,6 +37,8 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
+	# Include backports
+	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# Include blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -54,7 +54,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		dnsutils \
-		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -78,6 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
+    # More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -77,8 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
-    # More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
+	# More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -37,6 +37,8 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
+	# Include backports
+	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# Include blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -54,7 +54,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		dnsutils \
-		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -78,6 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
+    # More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -77,8 +77,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
-    # More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
+	# More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -55,7 +55,6 @@ RUN set -xe; \
 RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		dnsutils \
-		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -79,6 +78,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
+    # More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -78,8 +78,8 @@ RUN set -xe; \
 		zsh \
 		yarn \
 	;\
-    # More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null
+	# More recent version of git to get composer's git cache.
+	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -38,6 +38,8 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
+	# Include backports
+	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# Include blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \


### PR DESCRIPTION
`composer` supports using a cache for git repositories since ~1.2, but in order to actually use it, it needs git version `2.3.0-rc0` or newer, because since then it includes the `--dissociate` option. More context on that on the [composer related original PR](https://github.com/composer/composer/pull/5384).

The current cli container is using debian jessie, which has git `2.1.4`.

This change adds jessie backports repository to be able to get a newer one, currently it is `2.11.0`.