### PR TITLE
Release 2.0.1

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -181,7 +181,8 @@ RUN set -xe; \
 		memcache \
 		redis \
 		ssh2 \
-		xdebug \
+		# xdebug-2.5.5 is the last version with php5 support
+		xdebug-2.5.5 \
 	;\
 	docker-php-ext-enable \
 		gnupg \

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -43,6 +43,7 @@ shmop
 SimpleXML
 soap
 sockets
+sodium
 SPL
 sqlite3
 ssh2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CLI Docker image for Docksal
 
-This image is focused on console tools necessary to develop LAMP stack applications (namely Drupal and WordPress).
+This image is focused on console tools necessary to develop LAMP stack applications.
 
 This image(s) is part of the [Docksal](http://docksal.io) image library.
 
@@ -8,22 +8,21 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 ## Versions and image tag naming convention
 
 - Stable versions
-  - `<version>-php7`, `php7`, `latest` - PHP 7.0
-  - `<version>-php5`, `php5` - PHP 5.6
+  - `2.0-php5.6`, `php5.6` - PHP 5.6
+  - `2.0-php7.0`, `php7.0` - PHP 7.0
+  - `2.0-php7.1`, `php7.1` - PHP 7.1
+  - `2.0-php7.2`, `php7.2`, `latest` - PHP 7.2
 - Development versions
-  - `edge-php7` - PHP 7.0
-  - `edge-php5` - PHP 5.6
-
-Examples:
-
-- `docksal/cli:1.2-php7` - a specific stable image version with PHP7
-- `docksal/cli:php5` - the latest stable image version with PHP5
+  - `edge-php5.6` - PHP 5.6
+  - `edge-php7.0` - PHP 7.0
+  - `edge-php7.1` - PHP 7.1
+  - `edge-php7.2` - PHP 7.2
 
 
 ## Includes
 
 - php
-  - php-fpm && php-cli 5.6.x / 7.0.x
+  - php-fpm && php-cli
   - xdebug
   - composer
   - drush (6,7,8)
@@ -65,3 +64,5 @@ cli
     - XDEBUG_ENABLED=1
     ...
 ```
+
+See [docs](https://docs.docksal.io/en/master/tools/xdebug) on using Xdebug for web and cli PHP debugging.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -139,7 +139,7 @@ _healthcheck_wait ()
 
 	# Check xdebug was enabled
 	run docker exec "$NAME" php -m
-	echo "$output" | grep "xdebug"
+	echo "$output" | grep -e "^xdebug$"
 	unset output
 
 	# Check PHP CLI overrides


### PR DESCRIPTION
- Fixed missing `xdebug` extension for PHP 5.6 (#29)
  - Also fixed test checking `xdebug`
- Fixed tests for PHP 7.2
  - Added `sodium` to the list of modules for PHP 7.2. It was added upstream.
- Updated README.md (new image tags, misc.)
