### PR TITLE
PHP extension updates

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -123,6 +123,7 @@ RUN set -xe; \
 		libmemcached-dev \
 		libmhash-dev \
 		libpng12-dev \
+		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
 		zlib1g-dev \
@@ -140,12 +141,14 @@ RUN set -xe; \
 		libmcrypt4 \
 		libmhash2 \
 		libpng12-0 \
+		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
 		zlib1g \
 	;\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
+	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
 	docker-php-ext-install >/dev/null -j$(nproc) \
 		bcmath \
@@ -161,6 +164,8 @@ RUN set -xe; \
 		opcache \
 		pcntl \
 		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		soap \
 		sockets \
 		xsl \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -157,7 +157,6 @@ RUN set -xe; \
 		intl \
 		ldap \
 		mcrypt \
-		mysql \
 		mysqli \
 		opcache \
 		pcntl \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -144,7 +144,6 @@ RUN set -xe; \
 		libxslt1.1 \
 		zlib1g \
 	;\
-	docker-php-ext-configure >/dev/null hash --with-mhash; \
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	\
@@ -152,25 +151,19 @@ RUN set -xe; \
 		bcmath \
 		bz2 \
 		calendar\
-		dba \
 		exif \
 		gd \
 		gettext \
 		intl \
 		ldap \
 		mcrypt \
-		opcache \
-		pcntl \
 		mysql \
 		mysqli \
+		opcache \
+		pcntl \
 		pdo_mysql \
-		shmop \
 		soap \
 		sockets \
-		sysvmsg \
-		sysvsem \
-		sysvshm \
-		wddx \
 		xsl \
 		zip \
 	;\

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -112,10 +112,12 @@ ENV NOTVISIBLE "in users profile"
 RUN set -xe; \
 	buildDeps=" \
 		g++ \
+		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \
 		libicu-dev \
 		libjpeg62-turbo-dev \
+		libkrb5-dev \
 		libldap2-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
@@ -131,6 +133,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
+		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
 		libicu52 \
@@ -147,6 +150,7 @@ RUN set -xe; \
 		zlib1g \
 	;\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
+	docker-php-ext-configure >/dev/null imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
@@ -157,6 +161,7 @@ RUN set -xe; \
 		exif \
 		gd \
 		gettext \
+		imap \
 		intl \
 		ldap \
 		mcrypt \

--- a/5.6/php-modules.txt
+++ b/5.6/php-modules.txt
@@ -33,7 +33,9 @@ pcntl
 pcre
 PDO
 pdo_mysql
+pdo_pgsql
 pdo_sqlite
+pgsql
 Phar
 posix
 readline

--- a/5.6/php-modules.txt
+++ b/5.6/php-modules.txt
@@ -19,6 +19,7 @@ gnupg
 hash
 iconv
 imagick
+imap
 intl
 json
 ldap

--- a/5.6/php-modules.txt
+++ b/5.6/php-modules.txt
@@ -7,7 +7,6 @@ Core
 ctype
 curl
 date
-dba
 dom
 ereg
 exif
@@ -42,7 +41,6 @@ readline
 redis
 Reflection
 session
-shmop
 SimpleXML
 soap
 sockets
@@ -50,11 +48,7 @@ SPL
 sqlite3
 ssh2
 standard
-sysvmsg
-sysvsem
-sysvshm
 tokenizer
-wddx
 xml
 xmlreader
 xmlwriter

--- a/5.6/php-modules.txt
+++ b/5.6/php-modules.txt
@@ -26,7 +26,6 @@ libxml
 mbstring
 mcrypt
 memcache
-mysql
 mysqli
 mysqlnd
 openssl

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -38,18 +38,21 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# Include backports
+	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
-	# Include blackfire.io repo
+	# blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
-	# Include git-lfs repo
+	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
-	# Including yarn repo
+	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	# MSQSQL repo
+	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \
@@ -128,9 +131,13 @@ RUN set -xe; \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
+		unixodbc-dev \
 		zlib1g-dev \
 	"; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	# Necessary for msodbcsql17 (MSSQL)
+	ACCEPT_EULA=Y \
+	apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -149,6 +156,7 @@ RUN set -xe; \
 		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
+		msodbcsql17 \
 		zlib1g \
 	;\
 	# SSH2 must be installed from source
@@ -188,14 +196,18 @@ RUN set -xe; \
 		imagick \
 		# Use memcached (not memcache) for PHP 7.x
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 		xdebug \
 	;\
 	docker-php-ext-enable \
 		gnupg \
 		imagick \
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -123,6 +123,7 @@ RUN set -xe; \
 		libmemcached-dev \
 		libmhash-dev \
 		libpng12-dev \
+		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
 		zlib1g-dev \
@@ -142,6 +143,7 @@ RUN set -xe; \
 		libmemcachedutil2 \
 		libmhash2 \
 		libpng12-0 \
+		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
 		zlib1g \
@@ -151,6 +153,7 @@ RUN set -xe; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
+	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
 	docker-php-ext-install >/dev/null -j$(nproc) \
 		bcmath \
@@ -166,6 +169,8 @@ RUN set -xe; \
 		opcache \
 		pcntl \
 		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		soap \
 		sockets \
 		ssh2 \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -45,11 +45,11 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	# MSQSQL repo
 	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -162,7 +162,6 @@ RUN set -xe; \
 		intl \
 		ldap \
 		mcrypt \
-		mysql \
 		mysqli \
 		opcache \
 		pcntl \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -112,10 +112,12 @@ ENV NOTVISIBLE "in users profile"
 RUN set -xe; \
 	buildDeps=" \
 		g++ \
+		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \
 		libicu-dev \
 		libjpeg62-turbo-dev \
+		libkrb5-dev \
 		libldap2-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
@@ -131,6 +133,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
+		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
 		libicu52 \
@@ -152,6 +155,7 @@ RUN set -xe; \
 	git clone https://github.com/php/pecl-networking-ssh2.git /usr/src/php/ext/ssh2 && rm -rf /usr/src/php/ext/ssh2/.git; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
+	docker-php-ext-configure >/dev/null imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
@@ -162,6 +166,7 @@ RUN set -xe; \
 		exif \
 		gd \
 		gettext \
+		imap \
 		intl \
 		ldap \
 		mcrypt \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -149,7 +149,6 @@ RUN set -xe; \
 	# SSH2 must be installed from source
 	git clone https://github.com/php/pecl-networking-ssh2.git /usr/src/php/ext/ssh2 && rm -rf /usr/src/php/ext/ssh2/.git; \
 	\
-	docker-php-ext-configure >/dev/null hash --with-mhash; \
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	\
@@ -157,25 +156,20 @@ RUN set -xe; \
 		bcmath \
 		bz2 \
 		calendar\
-		dba \
 		exif \
 		gd \
 		gettext \
 		intl \
 		ldap \
 		mcrypt \
+		mysql \
+		mysqli \
 		opcache \
 		pcntl \
-		mysqli \
 		pdo_mysql \
-		shmop \
 		soap \
 		sockets \
 		ssh2 \
-		sysvmsg \
-		sysvsem \
-		sysvshm \
-		wddx \
 		xsl \
 		zip \
 	;\

--- a/7.0/php-modules.txt
+++ b/7.0/php-modules.txt
@@ -32,7 +32,9 @@ pcntl
 pcre
 PDO
 pdo_mysql
+pdo_pgsql
 pdo_sqlite
+pgsql
 Phar
 posix
 readline

--- a/7.0/php-modules.txt
+++ b/7.0/php-modules.txt
@@ -18,6 +18,7 @@ gnupg
 hash
 iconv
 imagick
+imap
 intl
 json
 ldap

--- a/7.0/php-modules.txt
+++ b/7.0/php-modules.txt
@@ -35,6 +35,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -47,6 +48,7 @@ soap
 sockets
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 tokenizer

--- a/7.0/php-modules.txt
+++ b/7.0/php-modules.txt
@@ -7,7 +7,6 @@ Core
 ctype
 curl
 date
-dba
 dom
 exif
 fileinfo
@@ -40,7 +39,6 @@ readline
 redis
 Reflection
 session
-shmop
 SimpleXML
 soap
 sockets
@@ -48,11 +46,7 @@ SPL
 sqlite3
 ssh2
 standard
-sysvmsg
-sysvsem
-sysvshm
 tokenizer
-wddx
 xml
 xmlreader
 xmlwriter

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -38,18 +38,21 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# Include backports
+	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
-	# Include blackfire.io repo
+	# blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
-	# Include git-lfs repo
+	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
-	# Including yarn repo
+	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	# MSQSQL repo
+	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \
@@ -128,9 +131,13 @@ RUN set -xe; \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
+		unixodbc-dev \
 		zlib1g-dev \
 	"; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	# Necessary for msodbcsql17 (MSSQL)
+	ACCEPT_EULA=Y \
+	apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -149,6 +156,7 @@ RUN set -xe; \
 		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
+		msodbcsql17 \
 		zlib1g \
 	;\
 	# SSH2 must be installed from source
@@ -188,14 +196,18 @@ RUN set -xe; \
 		imagick \
 		# Use memcached (not memcache) for PHP 7.x
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 		xdebug \
 	;\
 	docker-php-ext-enable \
 		gnupg \
 		imagick \
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -123,6 +123,7 @@ RUN set -xe; \
 		libmemcached-dev \
 		libmhash-dev \
 		libpng12-dev \
+		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
 		zlib1g-dev \
@@ -142,6 +143,7 @@ RUN set -xe; \
 		libmemcachedutil2 \
 		libmhash2 \
 		libpng12-0 \
+		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
 		zlib1g \
@@ -151,6 +153,7 @@ RUN set -xe; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
+	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
 	docker-php-ext-install >/dev/null -j$(nproc) \
 		bcmath \
@@ -166,6 +169,8 @@ RUN set -xe; \
 		opcache \
 		pcntl \
 		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		soap \
 		sockets \
 		ssh2 \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -45,11 +45,11 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	# MSQSQL repo
 	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -162,7 +162,6 @@ RUN set -xe; \
 		intl \
 		ldap \
 		mcrypt \
-		mysql \
 		mysqli \
 		opcache \
 		pcntl \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -112,10 +112,12 @@ ENV NOTVISIBLE "in users profile"
 RUN set -xe; \
 	buildDeps=" \
 		g++ \
+		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \
 		libicu-dev \
 		libjpeg62-turbo-dev \
+		libkrb5-dev \
 		libldap2-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
@@ -131,6 +133,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
+		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
 		libicu52 \
@@ -152,6 +155,7 @@ RUN set -xe; \
 	git clone https://github.com/php/pecl-networking-ssh2.git /usr/src/php/ext/ssh2 && rm -rf /usr/src/php/ext/ssh2/.git; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
+	docker-php-ext-configure >/dev/null imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
@@ -162,6 +166,7 @@ RUN set -xe; \
 		exif \
 		gd \
 		gettext \
+		imap \
 		intl \
 		ldap \
 		mcrypt \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -149,7 +149,6 @@ RUN set -xe; \
 	# SSH2 must be installed from source
 	git clone https://github.com/php/pecl-networking-ssh2.git /usr/src/php/ext/ssh2 && rm -rf /usr/src/php/ext/ssh2/.git; \
 	\
-	docker-php-ext-configure >/dev/null hash --with-mhash; \
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	\
@@ -157,25 +156,20 @@ RUN set -xe; \
 		bcmath \
 		bz2 \
 		calendar\
-		dba \
 		exif \
 		gd \
 		gettext \
 		intl \
 		ldap \
 		mcrypt \
+		mysql \
+		mysqli \
 		opcache \
 		pcntl \
-		mysqli \
 		pdo_mysql \
-		shmop \
 		soap \
 		sockets \
 		ssh2 \
-		sysvmsg \
-		sysvsem \
-		sysvshm \
-		wddx \
 		xsl \
 		zip \
 	;\

--- a/7.1/php-modules.txt
+++ b/7.1/php-modules.txt
@@ -32,7 +32,9 @@ pcntl
 pcre
 PDO
 pdo_mysql
+pdo_pgsql
 pdo_sqlite
+pgsql
 Phar
 posix
 readline

--- a/7.1/php-modules.txt
+++ b/7.1/php-modules.txt
@@ -18,6 +18,7 @@ gnupg
 hash
 iconv
 imagick
+imap
 intl
 json
 ldap

--- a/7.1/php-modules.txt
+++ b/7.1/php-modules.txt
@@ -35,6 +35,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -47,6 +48,7 @@ soap
 sockets
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 tokenizer

--- a/7.1/php-modules.txt
+++ b/7.1/php-modules.txt
@@ -7,7 +7,6 @@ Core
 ctype
 curl
 date
-dba
 dom
 exif
 fileinfo
@@ -40,7 +39,6 @@ readline
 redis
 Reflection
 session
-shmop
 SimpleXML
 soap
 sockets
@@ -48,11 +46,7 @@ SPL
 sqlite3
 ssh2
 standard
-sysvmsg
-sysvsem
-sysvshm
 tokenizer
-wddx
 xml
 xmlreader
 xmlwriter

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -152,7 +152,6 @@ RUN set -xe; \
 	# XDEBUG must be installed from source
 	git clone https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug && rm -rf /usr/src/php/ext/xdebug/.git; \
 	\
-	docker-php-ext-configure >/dev/null hash --with-mhash; \
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	\
@@ -160,26 +159,20 @@ RUN set -xe; \
 		bcmath \
 		bz2 \
 		calendar\
-		dba \
 		exif \
 		gd \
 		gettext \
 		intl \
 		ldap \
 		# mcrypt is removed from 7.2. See Deprecated features
+		mysql \
+		mysqli \
 		opcache \
 		pcntl \
-		mysqli \
 		pdo_mysql \
-		shmop \
 		soap \
 		sockets \
 		ssh2 \
-		sysvmsg \
-		sysvsem \
-		sysvshm \
-		wddx \
-		xdebug \
 		xsl \
 		zip \
 	;\

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -113,10 +113,12 @@ ENV NOTVISIBLE "in users profile"
 RUN set -xe; \
 	buildDeps=" \
 		g++ \
+		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \
 		libicu-dev \
 		libjpeg62-turbo-dev \
+		libkrb5-dev \
 		libldap2-dev \
 		libmagickcore-dev \
 		libmagickwand-dev \
@@ -132,6 +134,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
+		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
 		libicu57 \
@@ -155,6 +158,7 @@ RUN set -xe; \
 	git clone https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug && rm -rf /usr/src/php/ext/xdebug/.git; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
+	docker-php-ext-configure >/dev/null imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
 	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
@@ -165,6 +169,7 @@ RUN set -xe; \
 		exif \
 		gd \
 		gettext \
+		imap \
 		intl \
 		ldap \
 		# mcrypt is removed from 7.2. See Deprecated features

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -39,18 +39,21 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# Include backports
+	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
-	# Include blackfire.io repo
+	# blackfire.io repo
 	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
-	# Include git-lfs repo
+	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
-	# Including yarn repo
+	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	# MSQSQL repo
+	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \
@@ -129,9 +132,13 @@ RUN set -xe; \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
+		unixodbc-dev \
 		zlib1g-dev \
 	"; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	# Necessary for msodbcsql17 (MSSQL)
+	ACCEPT_EULA=Y \
+	apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -150,6 +157,7 @@ RUN set -xe; \
 		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
+		msodbcsql17 \
 		zlib1g \
 	;\
 	# SSH2 must be installed from source
@@ -192,13 +200,17 @@ RUN set -xe; \
 		imagick \
 		# Use memcached (not memcache) for PHP 7.x
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 	;\
 	docker-php-ext-enable \
 		gnupg \
 		imagick \
 		memcached \
+		pdo_sqlsrv \
 		redis \
+		sqlsrv \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -172,6 +172,7 @@ RUN set -xe; \
 		soap \
 		sockets \
 		ssh2 \
+		xdebug \
 		xsl \
 		zip \
 	;\

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -124,6 +124,7 @@ RUN set -xe; \
 		libmemcached-dev \
 		libmhash-dev \
 		libpng-dev \
+		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
 		zlib1g-dev \
@@ -143,6 +144,7 @@ RUN set -xe; \
 		libmemcachedutil2 \
 		libmhash2 \
 		libpng16-16 \
+		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \
 		zlib1g \
@@ -154,6 +156,7 @@ RUN set -xe; \
 	\
 	docker-php-ext-configure >/dev/null gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
 	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/x86_64-linux-gnu/; \
+	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
 	\
 	docker-php-ext-install >/dev/null -j$(nproc) \
 		bcmath \
@@ -169,6 +172,8 @@ RUN set -xe; \
 		opcache \
 		pcntl \
 		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
 		soap \
 		sockets \
 		ssh2 \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -46,11 +46,11 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' > /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' >> /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# yarn repo
 	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list; \
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	# MSQSQL repo
 	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -165,7 +165,6 @@ RUN set -xe; \
 		intl \
 		ldap \
 		# mcrypt is removed from 7.2. See Deprecated features
-		mysql \
 		mysqli \
 		opcache \
 		pcntl \

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -18,6 +18,7 @@ gnupg
 hash
 iconv
 imagick
+imap
 intl
 json
 ldap

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -7,7 +7,6 @@ Core
 ctype
 curl
 date
-dba
 dom
 exif
 fileinfo
@@ -39,7 +38,6 @@ readline
 redis
 Reflection
 session
-shmop
 SimpleXML
 soap
 sockets
@@ -48,11 +46,7 @@ SPL
 sqlite3
 ssh2
 standard
-sysvmsg
-sysvsem
-sysvshm
 tokenizer
-wddx
 xml
 xmlreader
 xmlwriter

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -31,7 +31,9 @@ pcntl
 pcre
 PDO
 pdo_mysql
+pdo_pgsql
 pdo_sqlite
+pgsql
 Phar
 posix
 readline

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -34,6 +34,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -47,6 +48,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 tokenizer

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -102,12 +102,15 @@ _healthcheck_wait ()
 
 	output=$(echo "$phpInfo" | grep "PHP Version")
 	echo "$output" | grep "${PHP_VERSION}"
+	unset output
 
 	output=$(echo "$phpInfo" | grep "memory_limit")
 	echo "$output" | grep "memory_limit => 512M => 512M"
+	unset output
 
 	output=$(echo "$phpInfo" | grep "sendmail_path")
 	echo "$output" | grep "sendmail_path => /usr/local/bin/mhsendmail --smtp-addr=mail:1025 => /usr/local/bin/mhsendmail --smtp-addr=mail:1025"
+	unset output
 
 	# Check PHP modules
 	run bash -c "docker exec '${NAME}' php -m | diff php-modules.txt -"


### PR DESCRIPTION
- removed archaic/not used extensions
  - `mysql` - mysqli or pdo_mysql should be used instead
  - `dba`, `shmop`, `sysvmsg`, `sysvsem`, `sysvshm, wddx`
- IMAP support via `imap` extension
- PostgreSQL support via `phsql` and `pdo_pgsql` extensions
- MSSQL support via `sqlsrv` and `pdo_sqlsrv` extensions (PHP 7.0+ only)
