### PR TITLE
Release 2.2.0

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -22,6 +22,7 @@ RUN set -xe; \
 		apt-transport-https \
 		ca-certificates \
 		curl \
+		gnupg \
 		locales \
 		wget \
 	;\
@@ -53,6 +54,9 @@ RUN set -xe; \
 
 # Additional packages
 RUN set -xe; \
+	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
+	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
+	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
@@ -63,7 +67,7 @@ RUN set -xe; \
 		imagemagick \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
-		libfcgi0ldbl \
+		libfcgi-bin \
 		mc \
 		mysql-client \
 		nano \
@@ -127,7 +131,7 @@ RUN set -xe; \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libmhash-dev \
-		libpng12-dev \
+		libpng-dev \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
@@ -139,14 +143,14 @@ RUN set -xe; \
 		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
-		libicu52 \
+		libicu57 \
 		libjpeg62-turbo \
 		libldap-2.4-2 \
-		libmagickcore-6.q16-2 \
-		libmagickwand-6.q16-2 \
+		libmagickcore-6.q16-3 \
+		libmagickwand-6.q16-3 \
 		libmcrypt4 \
 		libmhash2 \
-		libpng12-0 \
+		libpng16-16 \
 		libpq5 \
 		libssh2-1 \
 		libsybdb5 \

--- a/5.6/config/php/zz-php.ini
+++ b/5.6/config/php/zz-php.ini
@@ -14,3 +14,5 @@ sendmail_path = '/usr/local/bin/mhsendmail --smtp-addr=mail:1025'
 ; Extention settings
 [opcache]
 opcache.memory_consumption = 128
+[blackfire]
+blackfire.agent_socket = 'tcp://blackfire:8707'

--- a/5.6/php-modules.txt
+++ b/5.6/php-modules.txt
@@ -27,6 +27,7 @@ libxml
 mbstring
 mcrypt
 memcache
+mhash
 mssql
 mysqli
 mysqlnd

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
-# Why apply a fix/woraround for this at startup.
+# We apply a fix/workaround for this at startup.
 chown "$HOST_UID:$HOST_GID" /var/www
 
 # Initialization steps completed. Create a pid file to mark the container as healthy

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -65,7 +65,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$XDEBUG_ENABLED" != "" ]] && [[ "$XDEBUG_ENABLED" != "0" ]] && xdebug_enable
 
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
-# To not bloat the image size permissions on the home folder are reset during image startup (in startup.sh)
+# To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -10,7 +10,7 @@ DEBUG=${DEBUG:-0}
 [[ "$1" == "supervisord" ]] && DEBUG=1
 echo-debug ()
 {
-	[[ "$DEBUG" != 0 ]] && echo "$@"
+	[[ "$DEBUG" != 0 ]] && echo "$(date +"%F %H:%M:%S") | $@"
 }
 
 uid_gid_reset ()

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" >/dev/null 2>&1
 }
 
 # Process templates

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN"
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
 }
 
 # Process templates

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -22,6 +22,7 @@ RUN set -xe; \
 		apt-transport-https \
 		ca-certificates \
 		curl \
+		gnupg \
 		locales \
 		wget \
 	;\
@@ -56,6 +57,9 @@ RUN set -xe; \
 
 # Additional packages
 RUN set -xe; \
+	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
+	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
+	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
@@ -66,7 +70,7 @@ RUN set -xe; \
 		imagemagick \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
-		libfcgi0ldbl \
+		libfcgi-bin \
 		mc \
 		mysql-client \
 		nano \
@@ -129,7 +133,7 @@ RUN set -xe; \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libmhash-dev \
-		libpng12-dev \
+		libpng-dev \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
@@ -145,16 +149,16 @@ RUN set -xe; \
 		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
-		libicu52 \
+		libicu57 \
 		libjpeg62-turbo \
 		libldap-2.4-2 \
-		libmagickcore-6.q16-2 \
-		libmagickwand-6.q16-2 \
+		libmagickcore-6.q16-3 \
+		libmagickwand-6.q16-3 \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
 		libmhash2 \
-		libpng12-0 \
+		libpng16-16 \
 		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \

--- a/7.0/config/php/zz-php.ini
+++ b/7.0/config/php/zz-php.ini
@@ -13,3 +13,5 @@ sendmail_path = '/usr/local/bin/mhsendmail --smtp-addr=mail:1025'
 ; Extention settings
 [opcache]
 opcache.memory_consumption = 128
+[blackfire]
+blackfire.agent_socket = 'tcp://blackfire:8707'

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
-# Why apply a fix/woraround for this at startup.
+# We apply a fix/workaround for this at startup.
 chown "$HOST_UID:$HOST_GID" /var/www
 
 # Initialization steps completed. Create a pid file to mark the container as healthy

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -65,7 +65,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$XDEBUG_ENABLED" != "" ]] && [[ "$XDEBUG_ENABLED" != "0" ]] && xdebug_enable
 
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
-# To not bloat the image size permissions on the home folder are reset during image startup (in startup.sh)
+# To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -10,7 +10,7 @@ DEBUG=${DEBUG:-0}
 [[ "$1" == "supervisord" ]] && DEBUG=1
 echo-debug ()
 {
-	[[ "$DEBUG" != 0 ]] && echo "$@"
+	[[ "$DEBUG" != 0 ]] && echo "$(date +"%F %H:%M:%S") | $@"
 }
 
 uid_gid_reset ()

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" >/dev/null 2>&1
 }
 
 # Process templates

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN"
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
 }
 
 # Process templates

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -22,6 +22,7 @@ RUN set -xe; \
 		apt-transport-https \
 		ca-certificates \
 		curl \
+		gnupg \
 		locales \
 		wget \
 	;\
@@ -56,6 +57,9 @@ RUN set -xe; \
 
 # Additional packages
 RUN set -xe; \
+	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
+	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
+	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
@@ -66,7 +70,7 @@ RUN set -xe; \
 		imagemagick \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
-		libfcgi0ldbl \
+		libfcgi-bin \
 		mc \
 		mysql-client \
 		nano \
@@ -129,7 +133,7 @@ RUN set -xe; \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libmhash-dev \
-		libpng12-dev \
+		libpng-dev \
 		libpq-dev \
 		libssh2-1-dev \
 		libxslt1-dev \
@@ -145,16 +149,16 @@ RUN set -xe; \
 		libc-client2007e \
 		libfreetype6 \
 		libgpgme11 \
-		libicu52 \
+		libicu57 \
 		libjpeg62-turbo \
 		libldap-2.4-2 \
-		libmagickcore-6.q16-2 \
-		libmagickwand-6.q16-2 \
+		libmagickcore-6.q16-3 \
+		libmagickwand-6.q16-3 \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
 		libmhash2 \
-		libpng12-0 \
+		libpng16-16 \
 		libpq5 \
 		libssh2-1 \
 		libxslt1.1 \

--- a/7.1/config/php/zz-php.ini
+++ b/7.1/config/php/zz-php.ini
@@ -13,3 +13,5 @@ sendmail_path = '/usr/local/bin/mhsendmail --smtp-addr=mail:1025'
 ; Extention settings
 [opcache]
 opcache.memory_consumption = 128
+[blackfire]
+blackfire.agent_socket = 'tcp://blackfire:8707'

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
-# Why apply a fix/woraround for this at startup.
+# We apply a fix/workaround for this at startup.
 chown "$HOST_UID:$HOST_GID" /var/www
 
 # Initialization steps completed. Create a pid file to mark the container as healthy

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -65,7 +65,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$XDEBUG_ENABLED" != "" ]] && [[ "$XDEBUG_ENABLED" != "0" ]] && xdebug_enable
 
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
-# To not bloat the image size permissions on the home folder are reset during image startup (in startup.sh)
+# To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -10,7 +10,7 @@ DEBUG=${DEBUG:-0}
 [[ "$1" == "supervisord" ]] && DEBUG=1
 echo-debug ()
 {
-	[[ "$DEBUG" != 0 ]] && echo "$@"
+	[[ "$DEBUG" != 0 ]] && echo "$(date +"%F %H:%M:%S") | $@"
 }
 
 uid_gid_reset ()

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" >/dev/null 2>&1
 }
 
 # Process templates

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN"
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
 }
 
 # Process templates

--- a/7.2/config/php/zz-php.ini
+++ b/7.2/config/php/zz-php.ini
@@ -13,3 +13,5 @@ sendmail_path = '/usr/local/bin/mhsendmail --smtp-addr=mail:1025'
 ; Extention settings
 [opcache]
 opcache.memory_consumption = 128
+[blackfire]
+blackfire.agent_socket = 'tcp://blackfire:8707'

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
-# Why apply a fix/woraround for this at startup.
+# We apply a fix/workaround for this at startup.
 chown "$HOST_UID:$HOST_GID" /var/www
 
 # Initialization steps completed. Create a pid file to mark the container as healthy

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -65,7 +65,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$XDEBUG_ENABLED" != "" ]] && [[ "$XDEBUG_ENABLED" != "0" ]] && xdebug_enable
 
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
-# To not bloat the image size permissions on the home folder are reset during image startup (in startup.sh)
+# To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
 chown "$HOST_UID:$HOST_GID" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -10,7 +10,7 @@ DEBUG=${DEBUG:-0}
 [[ "$1" == "supervisord" ]] && DEBUG=1
 echo-debug ()
 {
-	[[ "$DEBUG" != 0 ]] && echo "$@"
+	[[ "$DEBUG" != 0 ]] && echo "$(date +"%F %H:%M:%S") | $@"
 }
 
 uid_gid_reset ()

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" >/dev/null 2>&1
 }
 
 # Process templates

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -46,7 +46,7 @@ render_tmpl ()
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
-	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN"
+	terminus auth:login --machine-token="$SECRET_TERMINUS_TOKEN" > /dev/null
 }
 
 # Process templates

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
   - drush
     - registry_rebuild
     - coder-8.x + phpcs
+    - Acquia Cloud API commands
   - drupal console launcher
+  - terminus (Pantheon)
   - wp-cli
 - ruby
   - ruby
@@ -75,3 +77,33 @@ cli
 ```
 
 See [docs](https://docs.docksal.io/en/master/tools/xdebug) on using Xdebug for web and cli PHP debugging.
+
+
+## Secrets and integrations
+
+`cli` can read secrets from environment variables and configure the respective integrations automatically at start.  
+
+The recommended place store secrets in Docksal is the global `$HOME/.docksal/docksal.env` file on the host. From there, 
+secrets are injected into the `cli` container's environment.
+
+Below is the list of secrets currently supported.
+
+`SECRET_SSH_PRIVATE_KEY`
+
+Use to pass a private SSH key. The key is stored in `/home/docker/.ssh/id_rsa` inside `cli` and will be considered 
+by the SSH client **in addition** to the keys loaded in `docksal-ssh-agent` when establishing a SSH connection 
+from within `cli`.
+
+`SECRET_ACAPI_EMAIL` and `SECRET_ACAPI_KEY`
+
+Credentials used to authenticate with [Acquia Cloud API](https://docs.acquia.com/acquia-cloud/api).  
+Stored in `/home/docker/.acquia/cloudapi.conf` inside `cli`. 
+
+Acquia Cloud API can be used via `ac-<command>` group of commands in Drush.
+
+`SECRET_TERMINUS_TOKEN`
+
+Credentials used to authenticate [Terminus](https://pantheon.io/docs/terminus) with Pantheon.
+Stored in `/home/docker/.terminus/` inside `cli`.
+
+Terminus is installed and available globally in `cli`.


### PR DESCRIPTION
- Silence `terminus auth:login` (otherwise it shows up in `fin run-cli`)
- Fix `id_rsa` key file permissions to avoid ssh warnings (Fixes #44)
- Added a timestamp in `echo-debug` in `startup.sh` (helps better understand container startup times)
- Fixed Blackfire PHP settings (Fixes docksal/docksal#561)
  - These got accidentally dropped during the 2.0 cli image upgrade
- Debian Stretch compatibility fix for 5.6, 7.0 and 7.1
  - Upstream `php:x.y-fpm` images switched to Debian Stretch. 7.2 was already on Stretch.

Resulting image size changes (compared to 2.1.0):

- php5.6: 359 MB => 297 MB (-62 MB)
- php7.0: 373 MB => 311 MB (- 62 MB)
- php7.1: 373 MB => 312 MB (- 61 MB)
- php7.2: 312 MB => 313 MB (+ 1MB)