### PR TITLE
Added Platform.sh CLI Tool Integration

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -275,8 +275,8 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-	TERMINUS_VERSION=1.8.0
 ENV PATH=$PATH:$HOME/.platformsh/ \
+	TERMINUS_VERSION=1.8.1
 	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -277,7 +277,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
 ENV PATH=$PATH:$HOME/.platformsh/ \
-	PLATFORM_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -296,7 +296,7 @@ RUN set -xe; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
 	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -275,8 +275,8 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-ENV PATH=$PATH:$HOME/.platformsh/ \
 	TERMINUS_VERSION=1.8.1
+ENV PATH=$PATH:$HOME/.platformsh \
 	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -277,7 +277,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -276,6 +276,8 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
+ENV PATH=$PATH:$HOME/.platformsh/ \
+	PLATFORM_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -293,6 +295,8 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	mkdir -p $HOME/.platformsh; \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -43,6 +43,17 @@ render_tmpl ()
 	fi
 }
 
+convert_secrets ()
+{
+	eval 'secrets=(${!'"SECRET_"'@})'
+	for secret_key in "${secrets[@]}"
+	do
+		secret_value=${!secret_key}
+		key=$(echo $secret_key | sed 's/SECRET_//g')
+		echo "${key}=\"${secret_value}\";"
+	done
+}
+
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
@@ -59,13 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval 'secrets=(${!'"SECRET_"'@})'
-for secret_key in "${secrets[@]}"
-do
-	secret_value=${!secret_key}
-	key=$(echo $secret_key | sed 's/SECRET_//g')
-	eval "${key}=\"${secret_value}\""
-done
+eval $(convert_secrets)
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -43,6 +43,9 @@ render_tmpl ()
 	fi
 }
 
+# Helper function to loop through all environment variables prefixed with SECRET_ and
+# convert to the equivalent variable without SECRET. (ex SECRET_TERMINUS_TOKEN has a variable
+# called TERMINUS_TOKEN.
 convert_secrets ()
 {
 	eval 'secrets=(${!SECRET_@})'
@@ -70,7 +73,9 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Convert all Environment Variables Prefixed with SECRET_ into
 convert_secrets
+
 # Source Docksalrc for when someone runs bash in the container
 echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -45,12 +45,12 @@ render_tmpl ()
 
 convert_secrets ()
 {
-	eval 'secrets=(${!'"SECRET_"'@})'
+	eval 'secrets=(${!SECRET_@})'
 	for secret_key in "${secrets[@]}"
 	do
 		secret_value=${!secret_key}
-		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
+		key=${secret_key#SECRET_}
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
 	done
 }
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=${secret_key#SECRET_}
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.docksalrc
 	done
 }
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -73,7 +73,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Convert all Environment Variables Prefixed with SECRET_ into
+# Convert all Environment Variables Prefixed with SECRET_
 convert_secrets
 
 # Source Docksalrc for when someone runs bash in the container

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
+		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
 	done
 }
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -71,6 +71,8 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
 convert_secrets
+# Source Docksalrc for when someone runs bash in the container
+echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -59,6 +59,11 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Platform CLI Token
+if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
+    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
+fi
+
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset
 

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -59,10 +59,13 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Platform CLI Token
-if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
-    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
-fi
+eval 'secrets=(${!'"SECRET_"'@})'
+for secret_key in "${secrets[@]}"
+do
+	secret_value=${!secret_key}
+	key=$(echo $secret_key | sed 's/SECRET_//g')
+	eval "${key}=\"${secret_value}\""
+done
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "${key}=\"${secret_value}\";"
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
 	done
 }
 
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval $(convert_secrets)
+convert_secrets
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -286,7 +286,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -284,7 +284,7 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-	TERMINUS_VERSION=1.8.0
+	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
 	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -285,6 +285,8 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
+ENV PATH=$PATH:$HOME/.platformsh \
+	PLATFORM_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -302,6 +304,8 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	mkdir -p $HOME/.platformsh; \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -286,7 +286,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORM_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -305,7 +305,7 @@ RUN set -xe; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
 	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -43,6 +43,17 @@ render_tmpl ()
 	fi
 }
 
+convert_secrets ()
+{
+	eval 'secrets=(${!'"SECRET_"'@})'
+	for secret_key in "${secrets[@]}"
+	do
+		secret_value=${!secret_key}
+		key=$(echo $secret_key | sed 's/SECRET_//g')
+		echo "${key}=\"${secret_value}\";"
+	done
+}
+
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
@@ -59,13 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval 'secrets=(${!'"SECRET_"'@})'
-for secret_key in "${secrets[@]}"
-do
-	secret_value=${!secret_key}
-	key=$(echo $secret_key | sed 's/SECRET_//g')
-	eval "${key}=\"${secret_value}\""
-done
+eval $(convert_secrets)
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -43,6 +43,9 @@ render_tmpl ()
 	fi
 }
 
+# Helper function to loop through all environment variables prefixed with SECRET_ and
+# convert to the equivalent variable without SECRET. (ex SECRET_TERMINUS_TOKEN has a variable
+# called TERMINUS_TOKEN.
 convert_secrets ()
 {
 	eval 'secrets=(${!SECRET_@})'
@@ -70,7 +73,9 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Convert all Environment Variables Prefixed with SECRET_ into
 convert_secrets
+
 # Source Docksalrc for when someone runs bash in the container
 echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -45,12 +45,12 @@ render_tmpl ()
 
 convert_secrets ()
 {
-	eval 'secrets=(${!'"SECRET_"'@})'
+	eval 'secrets=(${!SECRET_@})'
 	for secret_key in "${secrets[@]}"
 	do
 		secret_value=${!secret_key}
-		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
+		key=${secret_key#SECRET_}
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
 	done
 }
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=${secret_key#SECRET_}
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.docksalrc
 	done
 }
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -73,7 +73,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Convert all Environment Variables Prefixed with SECRET_ into
+# Convert all Environment Variables Prefixed with SECRET_
 convert_secrets
 
 # Source Docksalrc for when someone runs bash in the container

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
+		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
 	done
 }
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -71,6 +71,8 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
 convert_secrets
+# Source Docksalrc for when someone runs bash in the container
+echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -59,6 +59,11 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Platform CLI Token
+if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
+    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
+fi
+
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset
 

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -59,10 +59,13 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Platform CLI Token
-if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
-    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
-fi
+eval 'secrets=(${!'"SECRET_"'@})'
+for secret_key in "${secrets[@]}"
+do
+	secret_value=${!secret_key}
+	key=$(echo $secret_key | sed 's/SECRET_//g')
+	eval "${key}=\"${secret_value}\""
+done
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "${key}=\"${secret_value}\";"
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
 	done
 }
 
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval $(convert_secrets)
+convert_secrets
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -286,7 +286,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -284,7 +284,7 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-	TERMINUS_VERSION=1.8.0
+	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
 	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -285,6 +285,8 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
+ENV PATH=$PATH:$HOME/.platformsh \
+	PLATFORM_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -302,6 +304,8 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	mkdir -p $HOME/.platformsh; \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -286,7 +286,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.0
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORM_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -305,7 +305,7 @@ RUN set -xe; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
 	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -43,6 +43,17 @@ render_tmpl ()
 	fi
 }
 
+convert_secrets ()
+{
+	eval 'secrets=(${!'"SECRET_"'@})'
+	for secret_key in "${secrets[@]}"
+	do
+		secret_value=${!secret_key}
+		key=$(echo $secret_key | sed 's/SECRET_//g')
+		echo "${key}=\"${secret_value}\";"
+	done
+}
+
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
@@ -59,13 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval 'secrets=(${!'"SECRET_"'@})'
-for secret_key in "${secrets[@]}"
-do
-	secret_value=${!secret_key}
-	key=$(echo $secret_key | sed 's/SECRET_//g')
-	eval "${key}=\"${secret_value}\""
-done
+eval $(convert_secrets)
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -43,6 +43,9 @@ render_tmpl ()
 	fi
 }
 
+# Helper function to loop through all environment variables prefixed with SECRET_ and
+# convert to the equivalent variable without SECRET. (ex SECRET_TERMINUS_TOKEN has a variable
+# called TERMINUS_TOKEN.
 convert_secrets ()
 {
 	eval 'secrets=(${!SECRET_@})'
@@ -70,7 +73,9 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Convert all Environment Variables Prefixed with SECRET_ into
 convert_secrets
+
 # Source Docksalrc for when someone runs bash in the container
 echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -45,12 +45,12 @@ render_tmpl ()
 
 convert_secrets ()
 {
-	eval 'secrets=(${!'"SECRET_"'@})'
+	eval 'secrets=(${!SECRET_@})'
 	for secret_key in "${secrets[@]}"
 	do
 		secret_value=${!secret_key}
-		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
+		key=${secret_key#SECRET_}
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
 	done
 }
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=${secret_key#SECRET_}
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.docksalrc
 	done
 }
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -73,7 +73,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Convert all Environment Variables Prefixed with SECRET_ into
+# Convert all Environment Variables Prefixed with SECRET_
 convert_secrets
 
 # Source Docksalrc for when someone runs bash in the container

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
+		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
 	done
 }
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -71,6 +71,8 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
 convert_secrets
+# Source Docksalrc for when someone runs bash in the container
+echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -59,6 +59,11 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Platform CLI Token
+if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
+    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
+fi
+
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset
 

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -59,10 +59,13 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Platform CLI Token
-if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
-    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
-fi
+eval 'secrets=(${!'"SECRET_"'@})'
+for secret_key in "${secrets[@]}"
+do
+	secret_value=${!secret_key}
+	key=$(echo $secret_key | sed 's/SECRET_//g')
+	eval "${key}=\"${secret_value}\""
+done
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "${key}=\"${secret_value}\";"
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
 	done
 }
 
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval $(convert_secrets)
+convert_secrets
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -288,7 +288,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -288,7 +288,7 @@ ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.
 ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORM_CLI_VERSION=3.33.3
+	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -307,7 +307,7 @@ RUN set -xe; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
 	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -286,7 +286,7 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-	TERMINUS_VERSION=1.8.
+	TERMINUS_VERSION=1.8.1
 ENV PATH=$PATH:$HOME/.platformsh \
 	PLATFORMSH_CLI_VERSION=3.33.3
 RUN set -xe; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -286,7 +286,9 @@ ENV HOME /home/docker
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
-	TERMINUS_VERSION=1.8.0
+	TERMINUS_VERSION=1.8.
+ENV PATH=$PATH:$HOME/.platformsh \
+	PLATFORM_CLI_VERSION=3.33.3
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -304,6 +306,8 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	mkdir -p $HOME/.platformsh; \
+	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORM_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -43,6 +43,17 @@ render_tmpl ()
 	fi
 }
 
+convert_secrets ()
+{
+	eval 'secrets=(${!'"SECRET_"'@})'
+	for secret_key in "${secrets[@]}"
+	do
+		secret_value=${!secret_key}
+		key=$(echo $secret_key | sed 's/SECRET_//g')
+		echo "${key}=\"${secret_value}\";"
+	done
+}
+
 terminus_login ()
 {
 	echo-debug "Authenticating with Pantheon..."
@@ -59,13 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval 'secrets=(${!'"SECRET_"'@})'
-for secret_key in "${secrets[@]}"
-do
-	secret_value=${!secret_key}
-	key=$(echo $secret_key | sed 's/SECRET_//g')
-	eval "${key}=\"${secret_value}\""
-done
+eval $(convert_secrets)
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -43,6 +43,9 @@ render_tmpl ()
 	fi
 }
 
+# Helper function to loop through all environment variables prefixed with SECRET_ and
+# convert to the equivalent variable without SECRET. (ex SECRET_TERMINUS_TOKEN has a variable
+# called TERMINUS_TOKEN.
 convert_secrets ()
 {
 	eval 'secrets=(${!SECRET_@})'
@@ -70,7 +73,9 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Convert all Environment Variables Prefixed with SECRET_ into
 convert_secrets
+
 # Source Docksalrc for when someone runs bash in the container
 echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -45,12 +45,12 @@ render_tmpl ()
 
 convert_secrets ()
 {
-	eval 'secrets=(${!'"SECRET_"'@})'
+	eval 'secrets=(${!SECRET_@})'
 	for secret_key in "${secrets[@]}"
 	do
 		secret_value=${!secret_key}
-		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
+		key=${secret_key#SECRET_}
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
 	done
 }
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=${secret_key#SECRET_}
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.bashrc
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a ~/.docksalrc
 	done
 }
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -73,7 +73,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Convert all Environment Variables Prefixed with SECRET_ into
+# Convert all Environment Variables Prefixed with SECRET_
 convert_secrets
 
 # Source Docksalrc for when someone runs bash in the container

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
+		echo "export ${key}=\"${secret_value}\";" >> /etc/profile
 	done
 }
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -71,6 +71,8 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
 convert_secrets
+# Source Docksalrc for when someone runs bash in the container
+echo "source ~/.docksalrc" | sudo -u docker tee -a ~/.bashrc
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -59,6 +59,11 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
+# Platform CLI Token
+if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
+    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
+fi
+
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset
 

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -59,10 +59,13 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-# Platform CLI Token
-if [[ -n "$SECRET_PLATFORMSH_CLI_TOKEN" ]]; then
-    PLATFORMSH_CLI_TOKEN=$SECRET_PLATFORMSH_CLI_TOKEN
-fi
+eval 'secrets=(${!'"SECRET_"'@})'
+for secret_key in "${secrets[@]}"
+do
+	secret_value=${!secret_key}
+	key=$(echo $secret_key | sed 's/SECRET_//g')
+	eval "${key}=\"${secret_value}\""
+done
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -50,7 +50,7 @@ convert_secrets ()
 	do
 		secret_value=${!secret_key}
 		key=$(echo $secret_key | sed 's/SECRET_//g')
-		echo "${key}=\"${secret_value}\";"
+		echo "export ${key}=\"${secret_value}\";" | sudo -u docker tee -a $HOME/.docksalrc
 	done
 }
 
@@ -70,7 +70,7 @@ render_tmpl "$HOME_DIR/.acquia/cloudapi.conf"
 # Terminus authentication
 [[ "$SECRET_TERMINUS_TOKEN" ]] && terminus_login
 
-eval $(convert_secrets)
+convert_secrets
 
 # Docker user uid/gid mapping to the host user uid/gid
 [[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset

--- a/README.md
+++ b/README.md
@@ -106,3 +106,10 @@ Credentials used to authenticate [Terminus](https://pantheon.io/docs/terminus) w
 Stored in `/home/docker/.terminus/` inside `cli`.
 
 Terminus is installed and available globally in `cli`.
+
+`SECRET_PLATFORMSH_CLI_TOKEN`
+
+Credentials used to authenticate with the [Platform.sh CLI](https://github.com/platformsh/platformsh-cli) tool.
+Stored in `/home/docker/.platform` inside `cli`.
+
+Platform CLI is installed and available globally in `cli`.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -215,6 +215,11 @@ _healthcheck_wait ()
 	[[ ${status} == 0 ]]
 	unset output
 
+    $ Check Platform CLI version
+	run docker exec -u docker "$NAME" bash -c 'platform --version | grep "^Platform.sh CLI ${PLATFORM_VERSION}$"'
+	[[ ${status} == 0 ]]
+	unset output
+
 	### Cleanup ###
 	docker rm -vf "$NAME" >/dev/null 2>&1 || true
 }
@@ -267,13 +272,13 @@ _healthcheck_wait ()
 	docker run --name "$NAME" -d \
 		-v /home/docker \
 		-v $(pwd)/../tests:/var/www \
-		-e SECRET_PLATFORMSH_CLI_TOKEN=${PLATFORM_TOKEN} \
+		-e SECRET_PLATFORMSH_CLI_TOKEN \
 		"$IMAGE"
 	_healthcheck_wait
 
 	### Tests ###
 	run docker exec -u docker "$NAME" bash -c 'echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
-	run fin exec 'echo ${SECRET_PLATFORMSH_CLI_TOKEN}'
+	run fin exec 'echo ${PLATFORMSH_CLI_TOKEN}'
 	[[ "${output}" != "" ]]
 	unset output
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -215,8 +215,8 @@ _healthcheck_wait ()
 	[[ ${status} == 0 ]]
 	unset output
 
-    $ Check Platform CLI version
-	run docker exec -u docker "$NAME" bash -c 'platform --version | grep "^Platform.sh CLI ${PLATFORM_VERSION}$"'
+	# Check Platform CLI version
+	run docker exec -u docker "$NAME" bash -c 'platform --version | grep "^Platform.sh CLI ${PLATFORMSH_CLI_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -216,7 +216,7 @@ _healthcheck_wait ()
 	unset output
 
 	# Check Platform CLI version
-	run docker exec -u docker "$NAME" bash -c 'platform --version | grep "^Platform.sh CLI ${PLATFORMSH_CLI_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -c 'platform --version | grep "Platform.sh CLI ${PLATFORMSH_CLI_VERSION}"'
 	[[ ${status} == 0 ]]
 	unset output
 
@@ -282,12 +282,13 @@ _healthcheck_wait ()
 	[[ "${output}" != "" ]]
 	unset output
 
-	run fin exec 'platform auth:info'
 	run docker exec -u docker "$NAME" bash -c 'platform auth:info'
-	[[ ${status} == 0 ]] && [[ ! "${output}" =~ "Invalid API token" ]]
-	[[ "${output}" =~ "Sean Dietrich" ]]
+	echo "${output}"
+	[[ ${status} == 0 ]] &&
+	[[ ! "${output}" =~ "Invalid API token" ]] &&
+	[[ "${output}" =~ "Sean Dietrich" ]] &&
 	unset output
 
 	### Cleanup ###
-	docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	#docker rm -vf "$NAME" >/dev/null 2>&1 || true
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -280,7 +280,7 @@ _healthcheck_wait ()
 
 	# Confirm output is not empty and token is passed to container
 	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
-	[[ "${output" != "" ]]
+	[[ "${output}" != "" ]]
 	unset output
 
 	# Confirm token passed to container was converted without SECRET_

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -283,7 +283,6 @@ _healthcheck_wait ()
 	unset output
 
 	run docker exec -u docker "$NAME" bash -c 'platform auth:info'
-	echo "${output}"
 	[[ ${status} == 0 ]] &&
 	[[ ! "${output}" =~ "Invalid API token" ]] &&
 	[[ "${output}" =~ "Sean Dietrich" ]] &&

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -277,17 +277,24 @@ _healthcheck_wait ()
 	_healthcheck_wait
 
 	### Tests ###
+
+	# Confirm output is not empty and token is passed to container
 	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
+	[[ "${output" != "" ]]
+	unset output
+
+	# Confirm token passed to container was converted without SECRET_
 	run fin exec 'echo ${PLATFORMSH_CLI_TOKEN}'
 	[[ "${output}" != "" ]]
 	unset output
 
+	# Confirm Authentication
 	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; platform auth:info'
 	[[ ${status} == 0 ]] &&
 	[[ ! "${output}" =~ "Invalid API token" ]] &&
-	[[ "${output}" =~ "Sean Dietrich" ]] &&
+	[[ "${output}" =~ "Docksal App" ]] &&
 	unset output
 
 	### Cleanup ###
-	#docker rm -vf "$NAME" >/dev/null 2>&1 || true
+	docker rm -vf "$NAME" >/dev/null 2>&1 || true
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -272,15 +272,17 @@ _healthcheck_wait ()
 	_healthcheck_wait
 
 	### Tests ###
+	run docker exec -u docker "$NAME" bash -c 'echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
 	run fin exec 'echo ${SECRET_PLATFORMSH_CLI_TOKEN}'
 	[[ "${output}" != "" ]]
 	unset output
 
 	run fin exec 'platform auth:info'
+	run docker exec -u docker "$NAME" bash -c 'platform auth:info'
 	[[ ${status} == 0 ]] && [[ ! "${output}" =~ "Invalid API token" ]]
 	[[ "${output}" =~ "Sean Dietrich" ]]
 	unset output
 
 	### Cleanup ###
-	fin rm -f
+	docker rm -vf "$NAME" >/dev/null 2>&1 || true
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -277,12 +277,12 @@ _healthcheck_wait ()
 	_healthcheck_wait
 
 	### Tests ###
-	run docker exec -u docker "$NAME" bash -c 'echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
+	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; echo "${SECRET_PLATFORMSH_CLI_TOKEN}"'
 	run fin exec 'echo ${PLATFORMSH_CLI_TOKEN}'
 	[[ "${output}" != "" ]]
 	unset output
 
-	run docker exec -u docker "$NAME" bash -c 'platform auth:info'
+	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; platform auth:info'
 	[[ ${status} == 0 ]] &&
 	[[ ! "${output}" =~ "Invalid API token" ]] &&
 	[[ "${output}" =~ "Sean Dietrich" ]] &&

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -289,7 +289,7 @@ _healthcheck_wait ()
 	unset output
 
 	# Confirm Authentication
-	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; platform auth:info'
+	run docker exec -it -u docker "$NAME" bash -c 'source $HOME/.docksalrc >/dev/null 2>&1; platform auth:info -n'
 	[[ ${status} == 0 ]] &&
 	[[ ! "${output}" =~ "Invalid API token" ]] &&
 	[[ "${output}" =~ "Docksal App" ]] &&


### PR DESCRIPTION
Added tool for Platform.sh Integration.

Updated Readme.md to include `SECRET_PLATFORMSH_CLI_TOKEN` environment variable that is rewritten with `startup.sh` to just `PLATFORMSH_CLI_TOKEN` which is used to authenticate with Platform.sh.

Following Documentation on Platform.sh CLI tool https://github.com/platformsh/platformsh-cli

Platform is another big hosting company alongside Pantheon and Acquia. This integration could be an additional step to a more universal tool and yet another hosting company we can reach out to.

Other customizations through environment variables are as follows

Other customization is available via environment variables:

* `PLATFORMSH_CLI_DEBUG`: set to 1 to enable cURL debugging. _Warning_: this will print all request information in the terminal, including sensitive access tokens.
* `PLATFORMSH_CLI_DISABLE_CACHE`: set to 1 to disable caching
* `PLATFORMSH_CLI_SESSION_ID`: change user session (default 'default')
* `PLATFORMSH_CLI_TOKEN`: an API token. _Warning_: storing a secret in an environment variable can be insecure. It may be better to use `config.yaml` as above, depending on your system. The environment variable is preferable on CI systems like Jenkins and GitLab.
* `PLATFORMSH_CLI_UPDATES_CHECK`: set to 0 to disable the automatic updates check
* `CLICOLOR_FORCE`: set to 1 or 0 to force colorized output on or off, respectively
* `http_proxy` or `https_proxy`: specify a proxy for connecting to Platform.sh