### PR TITLE
Specify Cloud9 IDE Port

### DIFF
--- a/cloud9/Dockerfile
+++ b/cloud9/Dockerfile
@@ -8,7 +8,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Run as docker, so we don't have to fix permissions
 USER docker
 
-ENV C9SDK_PATH=/home/docker/c9sdk
+ENV C9SDK_PATH=/home/docker/c9sdk\
+	C9PORT=3000
+
 # Cloud9 IDE and dependencies
 RUN set -x; \
 	buildDeps=" \

--- a/cloud9/config/supervisord-cloud9.conf
+++ b/cloud9/config/supervisord-cloud9.conf
@@ -1,6 +1,6 @@
 # Cloud9 IDE
 [program:c9]
-command = gosu docker node /home/docker/c9sdk/server.js -l 0.0.0.0 -p 3000 -w /var/www -a :
+command = gosu docker node /home/docker/c9sdk/server.js -l 0.0.0.0 -p %(ENV_C9PORT)s -w /var/www -a :
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 stderr_logfile = /dev/stderr


### PR DESCRIPTION
Added ability for user to specify the Cloud9 IDE Port
Defaults to 3000 and using the C9PORT variable it can be customized so that it doesn't interfere with NodeJS applications

Solves #66 