### PR TITLE
PHP tools installation refactoring

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -226,7 +226,6 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
-	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
@@ -240,14 +239,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
-	# Magento2 Code Generator
-	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -286,6 +283,7 @@ ARG HOME=/home/docker
 
 # PHP tools (installed as user)
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
+	MG_CODEGEN_VERSION=1.10 \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
 	\
@@ -299,6 +297,8 @@ RUN set -xe; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
 	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Magento2 Code Generator
+	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus
 	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -44,7 +44,7 @@ RUN set -xe; \
 	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
-	curl -fssL https://packagecloud.io/gpg.key | apt-key add -; \
+	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe; \
 
 # Install basic packages
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
 		ca-certificates \
 		curl \
@@ -54,7 +55,8 @@ RUN set -xe; \
 	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
 	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
 		git-lfs \
@@ -81,7 +83,7 @@ RUN set -xe; \
 		zsh \
 	;\
 	# More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
+	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -138,7 +140,8 @@ RUN set -xe; \
 		libxslt1-dev \
 		zlib1g-dev \
 	"; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -254,7 +257,8 @@ RUN set -xe; \
 	# yarn repo
 	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		nodejs \
 		yarn \
 	;\
@@ -262,7 +266,8 @@ RUN set -xe; \
 
 # Ruby
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		ruby-full \
 		rlwrap \
 	;\

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -91,13 +91,18 @@ RUN set -xe; \
 	useradd -m -s /bin/bash -u 1000 -g 1000 -G sudo -p docker docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Install gosu and give access to the docker user primary group to use it.
-# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
-# https://github.com/tianon/gosu
+ENV GOSU_VERSION=1.10 \
+	GOMPLATE_VERSION=2.4.0
 RUN set -xe; \
-	curl -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	# Install gosu and give access to the docker user primary group to use it.
+	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
+	# https://github.com/tianon/gosu
+	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
-	chmod +sx /usr/local/bin/gosu
+	chmod +sx /usr/local/bin/gosu; \
+	# gomplate (to process configuration templates in startup.sh)
+	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
 # http://docs.docker.com/examples/running_ssh_service/
@@ -213,11 +218,12 @@ RUN set -xe; \
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
+	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
-	GOMPLATE_VERSION=2.4.0
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -232,11 +238,11 @@ RUN set -xe; \
 	# Magento2 Code Generator
 	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64 -o /usr/local/bin/blackfire; \
-	# gomplate
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
-	# Make all binaries executable in one shot
-	cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire gomplate;
+	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	# Platform.sh CLI
+	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	# Make all downloaded binaries executable in one shot
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -272,12 +278,9 @@ USER docker
 ENV HOME /home/docker
 
 # Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin \
-	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+ENV PATH=$PATH:$HOME/.composer/vendor/bin
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
-ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -295,8 +298,6 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
-	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -224,19 +224,19 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
-	DRUPAL_CONSOLE_VERSION=1.7.0 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
-	# Drush 8 (default)
+	# Drush 8 (global fallback)
 	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
 	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
-	# Drupal Console
-	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	# Drupal Console Launcher
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -11,6 +11,7 @@ RUN set -xe; \
 FROM php:5.6-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # Prevent services autoload (http://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/)
 RUN set -xe; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -42,10 +42,10 @@ RUN set -xe; \
 	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
-	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
+	curl -fssL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
-	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
+	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list;
 
@@ -97,11 +97,11 @@ RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
 	# https://github.com/tianon/gosu
-	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
 	chmod +sx /usr/local/bin/gosu; \
 	# gomplate (to process configuration templates in startup.sh)
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
 	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
@@ -226,21 +226,21 @@ ENV COMPOSER_VERSION=1.6.3 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
-	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
 	# Drush 8 (default)
-	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
+	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
-	curl -sSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
+	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
-	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
-	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
+	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Magento2 Code Generator
-	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
+	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
-	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
@@ -248,11 +248,11 @@ RUN set -xe; \
 ENV NODE_VERSION=8.x
 RUN set -xe; \
 	# Node.js repo
-	curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
 	echo "deb https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
 	echo "deb-src https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list; \
 	# yarn repo
-	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		nodejs \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -219,6 +219,7 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# PHP tools (installed globally)
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
@@ -281,31 +282,31 @@ ENV BUNDLE_PATH .bundler
 
 # All further RUN commands will run as the "docker" user
 USER docker
-ENV HOME /home/docker
+ARG HOME=/home/docker
 
-# Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin
-ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
+# PHP tools (installed as user)
+ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
+	\
+	# Composer based dependencies
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
-	# Drush modules
-	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	drush cc drush; \
-	# Drupal Coder w/ a matching version of PHP_CodeSniffer
-	composer global require drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Install cgr to use it in-place of `composer global require`
+	composer global require consolidation/cgr >/dev/null; \
 	# Composer parallel install plugin
 	composer global require hirak/prestissimo >/dev/null; \
+	# Drupal Coder w/ a matching version of PHP_CodeSniffer
+	cgr drupal/coder >/dev/null; \
+	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
 	# Terminus
-	# Installed in a dedicated directory to avoid dependency conflicts.
-	echo "\n"'PATH="$PATH:$HOME/.terminus/vendor/bin"' >> $HOME/.profile; \
-	mkdir -p $HOME/.terminus; \
-	# Run in a subshell since we are doing directory switching
-	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup
-	composer clear-cache
+	composer clear-cache; \
+	\
+	# Drush modules
+	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	drush cc drush
 
 USER root
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -11,6 +11,7 @@ RUN set -xe; \
 FROM php:7.0-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # Prevent services autoload (http://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/)
 RUN set -xe; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe; \
 
 # Install basic packages
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
 		ca-certificates \
 		curl \
@@ -57,7 +58,8 @@ RUN set -xe; \
 	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
 	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
 		git-lfs \
@@ -84,7 +86,7 @@ RUN set -xe; \
 		zsh \
 	;\
 	# More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
+	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -144,7 +146,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	# Necessary for msodbcsql17 (MSSQL)
 	ACCEPT_EULA=Y \
-	apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get -y --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -263,7 +265,8 @@ RUN set -xe; \
 	# yarn repo
 	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		nodejs \
 		yarn \
 	;\
@@ -271,7 +274,8 @@ RUN set -xe; \
 
 # Ruby
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		ruby-full \
 		rlwrap \
 	;\

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -94,13 +94,18 @@ RUN set -xe; \
 	useradd -m -s /bin/bash -u 1000 -g 1000 -G sudo -p docker docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Install gosu and give access to the docker user primary group to use it.
-# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
-# https://github.com/tianon/gosu
+ENV GOSU_VERSION=1.10 \
+	GOMPLATE_VERSION=2.4.0
 RUN set -xe; \
-	curl -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	# Install gosu and give access to the docker user primary group to use it.
+	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
+	# https://github.com/tianon/gosu
+	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
-	chmod +sx /usr/local/bin/gosu
+	chmod +sx /usr/local/bin/gosu; \
+	# gomplate (to process configuration templates in startup.sh)
+	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
 # http://docs.docker.com/examples/running_ssh_service/
@@ -222,11 +227,12 @@ RUN set -xe; \
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
+	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
-	GOMPLATE_VERSION=2.4.0
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -241,11 +247,11 @@ RUN set -xe; \
 	# Magento2 Code Generator
 	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64 -o /usr/local/bin/blackfire; \
-	# gomplate
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
-	# Make all binaries executable in one shot
-	cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire gomplate;
+	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	# Platform.sh CLI
+	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	# Make all downloaded binaries executable in one shot
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -281,12 +287,9 @@ USER docker
 ENV HOME /home/docker
 
 # Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin \
-	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+ENV PATH=$PATH:$HOME/.composer/vendor/bin
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
-ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -304,8 +307,6 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
-	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -227,6 +227,7 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# PHP tools (installed globally)
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
@@ -289,31 +290,31 @@ ENV BUNDLE_PATH .bundler
 
 # All further RUN commands will run as the "docker" user
 USER docker
-ENV HOME /home/docker
+ARG HOME=/home/docker
 
-# Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin
-ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
+# PHP tools (installed as user)
+ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
+	\
+	# Composer based dependencies
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
-	# Drush modules
-	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	drush cc drush; \
-	# Drupal Coder w/ a matching version of PHP_CodeSniffer
-	composer global require drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Install cgr to use it in-place of `composer global require`
+	composer global require consolidation/cgr >/dev/null; \
 	# Composer parallel install plugin
 	composer global require hirak/prestissimo >/dev/null; \
+	# Drupal Coder w/ a matching version of PHP_CodeSniffer
+	cgr drupal/coder >/dev/null; \
+	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
 	# Terminus
-	# Installed in a dedicated directory to avoid dependency conflicts.
-	echo "\n"'PATH="$PATH:$HOME/.terminus/vendor/bin"' >> $HOME/.profile; \
-	mkdir -p $HOME/.terminus; \
-	# Run in a subshell since we are doing directory switching
-	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup
-	composer clear-cache
+	composer clear-cache; \
+	\
+	# Drush modules
+	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	drush cc drush
 
 USER root
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -232,19 +232,19 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
-	DRUPAL_CONSOLE_VERSION=1.7.0 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
-	# Drush 8 (default)
+	# Drush 8 (global fallback)
 	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
 	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
-	# Drupal Console
-	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	# Drupal Console Launcher
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -42,14 +42,14 @@ RUN set -xe; \
 	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
-	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
+	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
-	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
+	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
-	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
@@ -100,11 +100,11 @@ RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
 	# https://github.com/tianon/gosu
-	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
 	chmod +sx /usr/local/bin/gosu; \
 	# gomplate (to process configuration templates in startup.sh)
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
 	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
@@ -235,21 +235,21 @@ ENV COMPOSER_VERSION=1.6.3 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
-	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
 	# Drush 8 (default)
-	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
+	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
-	curl -sSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
+	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
-	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
-	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
+	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Magento2 Code Generator
-	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
+	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
-	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
@@ -257,11 +257,11 @@ RUN set -xe; \
 ENV NODE_VERSION=8.x
 RUN set -xe; \
 	# Node.js repo
-	curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
 	echo "deb https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
 	echo "deb-src https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list; \
 	# yarn repo
-	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		nodejs \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -234,7 +234,6 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
-	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
@@ -248,14 +247,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
-	# Magento2 Code Generator
-	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -294,6 +291,7 @@ ARG HOME=/home/docker
 
 # PHP tools (installed as user)
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
+	MG_CODEGEN_VERSION=1.10 \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
 	\
@@ -307,6 +305,8 @@ RUN set -xe; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
 	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Magento2 Code Generator
+	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus
 	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -11,6 +11,7 @@ RUN set -xe; \
 FROM php:7.1-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # Prevent services autoload (http://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/)
 RUN set -xe; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe; \
 
 # Install basic packages
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
 		ca-certificates \
 		curl \
@@ -57,7 +58,8 @@ RUN set -xe; \
 	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
 	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
 		git-lfs \
@@ -84,7 +86,7 @@ RUN set -xe; \
 		zsh \
 	;\
 	# More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
+	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -144,7 +146,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	# Necessary for msodbcsql17 (MSSQL)
 	ACCEPT_EULA=Y \
-	apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get -y --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -263,7 +265,8 @@ RUN set -xe; \
 	# yarn repo
 	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		nodejs \
 		yarn \
 	;\
@@ -271,7 +274,8 @@ RUN set -xe; \
 
 # Ruby
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		ruby-full \
 		rlwrap \
 	;\

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -94,13 +94,18 @@ RUN set -xe; \
 	useradd -m -s /bin/bash -u 1000 -g 1000 -G sudo -p docker docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Install gosu and give access to the docker user primary group to use it.
-# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
-# https://github.com/tianon/gosu
+ENV GOSU_VERSION=1.10 \
+	GOMPLATE_VERSION=2.4.0
 RUN set -xe; \
-	curl -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	# Install gosu and give access to the docker user primary group to use it.
+	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
+	# https://github.com/tianon/gosu
+	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
-	chmod +sx /usr/local/bin/gosu
+	chmod +sx /usr/local/bin/gosu; \
+	# gomplate (to process configuration templates in startup.sh)
+	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
 # http://docs.docker.com/examples/running_ssh_service/
@@ -222,11 +227,12 @@ RUN set -xe; \
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
+	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
-	GOMPLATE_VERSION=2.4.0
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -241,11 +247,11 @@ RUN set -xe; \
 	# Magento2 Code Generator
 	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64 -o /usr/local/bin/blackfire; \
-	# gomplate
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
-	# Make all binaries executable in one shot
-	cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire gomplate;
+	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	# Platform.sh CLI
+	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	# Make all downloaded binaries executable in one shot
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -281,12 +287,9 @@ USER docker
 ENV HOME /home/docker
 
 # Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin \
-	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+ENV PATH=$PATH:$HOME/.composer/vendor/bin
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
-ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -304,8 +307,6 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
-	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -227,6 +227,7 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# PHP tools (installed globally)
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
@@ -289,31 +290,31 @@ ENV BUNDLE_PATH .bundler
 
 # All further RUN commands will run as the "docker" user
 USER docker
-ENV HOME /home/docker
+ARG HOME=/home/docker
 
-# Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin
-ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
+# PHP tools (installed as user)
+ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
+	\
+	# Composer based dependencies
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
-	# Drush modules
-	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	drush cc drush; \
-	# Drupal Coder w/ a matching version of PHP_CodeSniffer
-	composer global require drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Install cgr to use it in-place of `composer global require`
+	composer global require consolidation/cgr >/dev/null; \
 	# Composer parallel install plugin
 	composer global require hirak/prestissimo >/dev/null; \
+	# Drupal Coder w/ a matching version of PHP_CodeSniffer
+	cgr drupal/coder >/dev/null; \
+	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
 	# Terminus
-	# Installed in a dedicated directory to avoid dependency conflicts.
-	echo "\n"'PATH="$PATH:$HOME/.terminus/vendor/bin"' >> $HOME/.profile; \
-	mkdir -p $HOME/.terminus; \
-	# Run in a subshell since we are doing directory switching
-	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup
-	composer clear-cache
+	composer clear-cache; \
+	\
+	# Drush modules
+	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	drush cc drush
 
 USER root
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -232,19 +232,19 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
-	DRUPAL_CONSOLE_VERSION=1.7.0 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
-	# Drush 8 (default)
+	# Drush 8 (global fallback)
 	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
 	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
-	# Drupal Console
-	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	# Drupal Console Launcher
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -42,14 +42,14 @@ RUN set -xe; \
 	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
-	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
+	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
-	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
+	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
-	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
@@ -100,11 +100,11 @@ RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
 	# https://github.com/tianon/gosu
-	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
 	chmod +sx /usr/local/bin/gosu; \
 	# gomplate (to process configuration templates in startup.sh)
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
 	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
@@ -235,21 +235,21 @@ ENV COMPOSER_VERSION=1.6.3 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
-	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
 	# Drush 8 (default)
-	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
+	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
-	curl -sSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
+	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
-	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
-	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
+	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Magento2 Code Generator
-	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
+	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
-	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
@@ -257,11 +257,11 @@ RUN set -xe; \
 ENV NODE_VERSION=8.x
 RUN set -xe; \
 	# Node.js repo
-	curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
 	echo "deb https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
 	echo "deb-src https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list; \
 	# yarn repo
-	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		nodejs \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -234,7 +234,6 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
-	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
@@ -248,14 +247,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
-	# Magento2 Code Generator
-	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -294,6 +291,7 @@ ARG HOME=/home/docker
 
 # PHP tools (installed as user)
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
+	MG_CODEGEN_VERSION=1.10 \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
 	\
@@ -307,6 +305,8 @@ RUN set -xe; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
 	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Magento2 Code Generator
+	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus
 	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -236,7 +236,6 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
-	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
@@ -250,14 +249,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
-	# Magento2 Code Generator
-	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -296,6 +293,7 @@ ARG HOME=/home/docker
 
 # PHP tools (installed as user)
 ENV PATH=$PATH:$HOME/.composer/vendor/bin \
+	MG_CODEGEN_VERSION=1.10 \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
 	\
@@ -309,6 +307,8 @@ RUN set -xe; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
 	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Magento2 Code Generator
+	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus
 	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -11,6 +11,7 @@ RUN set -xe; \
 FROM php:7.2-fpm
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
 # Prevent services autoload (http://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/)
 RUN set -xe; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -229,6 +229,7 @@ RUN set -xe; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# PHP tools (installed globally)
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
@@ -291,31 +292,31 @@ ENV BUNDLE_PATH .bundler
 
 # All further RUN commands will run as the "docker" user
 USER docker
-ENV HOME /home/docker
+ARG HOME=/home/docker
 
-# Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin
-ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
+# PHP tools (installed as user)
+ENV PATH=$PATH:$HOME/.composer/vendor/bin \
 	TERMINUS_VERSION=1.8.1
 RUN set -xe; \
+	\
+	# Composer based dependencies
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
-	# Drush modules
-	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	drush cc drush; \
-	# Drupal Coder w/ a matching version of PHP_CodeSniffer
-	composer global require drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	# Install cgr to use it in-place of `composer global require`
+	composer global require consolidation/cgr >/dev/null; \
 	# Composer parallel install plugin
 	composer global require hirak/prestissimo >/dev/null; \
+	# Drupal Coder w/ a matching version of PHP_CodeSniffer
+	cgr drupal/coder >/dev/null; \
+	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
 	# Terminus
-	# Installed in a dedicated directory to avoid dependency conflicts.
-	echo "\n"'PATH="$PATH:$HOME/.terminus/vendor/bin"' >> $HOME/.profile; \
-	mkdir -p $HOME/.terminus; \
-	# Run in a subshell since we are doing directory switching
-	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
+	cgr pantheon-systems/terminus:${TERMINUS_VERSION} >/dev/null; \
 	# Cleanup
-	composer clear-cache
+	composer clear-cache; \
+	\
+	# Drush modules
+	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	drush cc drush
 
 USER root
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -42,14 +42,14 @@ RUN set -xe; \
 	# backports repo
 	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
-	curl -sSL https://packagecloud.io/gpg.key | apt-key add -; \
+	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
-	curl -sSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
+	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
 	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
-	curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
@@ -100,11 +100,11 @@ RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
 	# https://github.com/tianon/gosu
-	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	curl -fsSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
 	chmod +sx /usr/local/bin/gosu; \
 	# gomplate (to process configuration templates in startup.sh)
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
 	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
@@ -237,21 +237,21 @@ ENV COMPOSER_VERSION=1.6.3 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
-	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
 	# Drush 8 (default)
-	curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
+	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
-	curl -sSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
+	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
 	# Drupal Console
-	curl -sSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
-	curl -sSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
+	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Magento2 Code Generator
-	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
+	curl -fsSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
-	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
@@ -259,11 +259,11 @@ RUN set -xe; \
 ENV NODE_VERSION=8.x
 RUN set -xe; \
 	# Node.js repo
-	curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
+	curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -; \
 	echo "deb https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
 	echo "deb-src https://deb.nodesource.com/node_${NODE_VERSION} jessie main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list; \
 	# yarn repo
-	curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
 	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
 		nodejs \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -234,19 +234,19 @@ ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
 	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
-	DRUPAL_CONSOLE_VERSION=1.7.0 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	BLACKFIRE_VERSION=1.15.0 \
 	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
-	# Drush 8 (default)
+	# Drush 8 (global fallback)
 	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
 	# Drush Launcher
 	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
-	# Drupal Console
-	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	# Drupal Console Launcher
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -94,13 +94,18 @@ RUN set -xe; \
 	useradd -m -s /bin/bash -u 1000 -g 1000 -G sudo -p docker docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Install gosu and give access to the docker user primary group to use it.
-# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
-# https://github.com/tianon/gosu
+ENV GOSU_VERSION=1.10 \
+	GOMPLATE_VERSION=2.4.0
 RUN set -xe; \
-	curl -sSL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
+	# Install gosu and give access to the docker user primary group to use it.
+	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
+	# https://github.com/tianon/gosu
+	curl -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" -o /usr/local/bin/gosu; \
 	chown root:"$(id -gn docker)" /usr/local/bin/gosu; \
-	chmod +sx /usr/local/bin/gosu
+	chmod +sx /usr/local/bin/gosu; \
+	# gomplate (to process configuration templates in startup.sh)
+	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
+	chmod +x /usr/local/bin/gomplate
 
 # Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
 # http://docs.docker.com/examples/running_ssh_service/
@@ -224,11 +229,12 @@ RUN set -xe; \
 ENV COMPOSER_VERSION=1.6.3 \
 	DRUSH_VERSION=8.1.16 \
 	DRUSH_LAUNCHER_VERSION=0.6.0 \
+	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8 \
 	DRUPAL_CONSOLE_VERSION=1.7.0 \
 	WPCLI_VERSION=1.5.0 \
 	MG_CODEGEN_VERSION=1.10 \
 	BLACKFIRE_VERSION=1.15.0 \
-	GOMPLATE_VERSION=2.4.0
+	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Composer
 	curl -sSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -243,11 +249,11 @@ RUN set -xe; \
 	# Magento2 Code Generator
 	curl -sSL "https://github.com/staempfli/magento2-code-generator/releases/download/${MG_CODEGEN_VERSION}/mg2-codegen.phar" -o /usr/local/bin/mg2-codegen; \
 	# Blackfire CLI
-	curl -sSL https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64 -o /usr/local/bin/blackfire; \
-	# gomplate
-	curl -sSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64-slim -o /usr/local/bin/gomplate; \
-	# Make all binaries executable in one shot
-	cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire gomplate;
+	curl -sSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
+	# Platform.sh CLI
+	curl -sSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	# Make all downloaded binaries executable in one shot
+	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp mg2-codegen blackfire platform);
 
 # Node.js
 ENV NODE_VERSION=8.x
@@ -283,12 +289,9 @@ USER docker
 ENV HOME /home/docker
 
 # Install Composer based dependencies
-ENV PATH=$PATH:$HOME/.composer/vendor/bin \
-	DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+ENV PATH=$PATH:$HOME/.composer/vendor/bin
 ENV PATH=$PATH:$HOME/.terminus/vendor/bin \
 	TERMINUS_VERSION=1.8.1
-ENV PATH=$PATH:$HOME/.platformsh \
-	PLATFORMSH_CLI_VERSION=3.33.5
 RUN set -xe; \
 	# Add composer bin directory to PATH
 	echo "\n"'PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
@@ -306,8 +309,6 @@ RUN set -xe; \
 	mkdir -p $HOME/.terminus; \
 	# Run in a subshell since we are doing directory switching
 	(cd $HOME/.terminus && composer require pantheon-systems/terminus:${TERMINUS_VERSION}); \
-	mkdir -p $HOME/.platformsh; \
-	(cd $HOME/.platformsh && curl -o platform -L "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" && chmod 755 platform); \
 	# Cleanup
 	composer clear-cache
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -18,7 +18,8 @@ RUN set -xe; \
 
 # Install basic packages
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
 		ca-certificates \
 		curl \
@@ -57,7 +58,8 @@ RUN set -xe; \
 	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
 	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
 	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
 		git-lfs \
@@ -84,7 +86,7 @@ RUN set -xe; \
 		zsh \
 	;\
 	# More recent version of git to get composer's git cache.
-	apt-get -y --force-yes --no-install-recommends -t jessie-backports install git >/dev/null ;\
+	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
@@ -144,7 +146,7 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	# Necessary for msodbcsql17 (MSSQL)
 	ACCEPT_EULA=Y \
-	apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get -y --no-install-recommends install >/dev/null \
 		$buildDeps \
 		blackfire-php \
 		libc-client2007e \
@@ -265,7 +267,8 @@ RUN set -xe; \
 	# yarn repo
 	curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		nodejs \
 		yarn \
 	;\
@@ -273,7 +276,8 @@ RUN set -xe; \
 
 # Ruby
 RUN set -xe; \
-	apt-get update >/dev/null; apt-get -y --force-yes --no-install-recommends install >/dev/null \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
 		ruby-full \
 		rlwrap \
 	;\

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -184,7 +184,7 @@ _healthcheck_wait ()
 	unset output
 
 	# Check Drupal Console version
-	run docker exec -u docker "$NAME" bash -c 'drupal --version | grep "^Drupal Console Launcher ${DRUPAL_CONSOLE_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -c 'drupal --version | grep "^Drupal Console Launcher ${DRUPAL_CONSOLE_LAUNCHER_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -194,9 +194,10 @@ _healthcheck_wait ()
 	unset output
 
 	# Check Magento 2 Code Generator version
-	# TODO: this should not require running with sudo - sudo should be removed ones the following issues is addressed:
-	# https://github.com/staempfli/magento2-code-generator/issues/11
-	run docker exec -u docker "$NAME" bash -c 'sudo mg2-codegen --version | grep "^mg2-codegen ${MG_CODEGEN_VERSION}$"'
+	# TODO: this needs to be replaced with the actual version check
+	# See https://github.com/staempfli/magento2-code-generator/issues/15
+	#run docker exec -u docker "$NAME" bash -c 'mg2-codegen --version | grep "^mg2-codegen ${MG_CODEGEN_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -c 'mg2-codegen --version | grep "^mg2-codegen @git-version@$"'
 	[[ ${status} == 0 ]]
 	unset output
 


### PR DESCRIPTION
See comments in commits for details.

Side note: I experimented and compared installing all PHP tools with composer (`~/.composer/`) vs phar (`/usr/local/bin`) where possible. phar based installation is simpler and the resulting image size is about 40MB smaller. However, compressed image size is only 4MB smaller.

Not sure which method should be considered the best practice. Staying with the phar approach for now.