### PR TITLE
Release 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ env:
     - VERSION=7.1
     - VERSION=7.2
 
+# Skip building master.
+# Stable image tags are pushed during release tag builds so that stable and release tags match on Docker Hub.
+branches:
+  except:
+  - master
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install libfcgi0ldbl  # cgi-fcgi binary used in tests

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -60,6 +60,7 @@ RUN set -xe; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
+		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -84,8 +85,6 @@ RUN set -xe; \
 		zip \
 		zsh \
 	;\
-	# More recent version of git to get composer's git cache.
-	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -22,8 +22,9 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
-		ca-certificates \
-		curl \
+		# ca-certificates and curl come from upstream
+		#ca-certificates \
+		#curl \
 		gnupg \
 		locales \
 		wget \
@@ -120,9 +121,10 @@ ENV NOTVISIBLE "in users profile"
 
 # PHP
 RUN set -xe; \
+	# Note: essential build tools (g++, gcc, make, etc) are included upstream as persistent packages.
+	# See https://github.com/docker-library/php/blob/4af0a8734a48ab84ee96de513aabc45418b63dc5/7.2/stretch/fpm/Dockerfile#L18-L37
 	buildDeps=" \
 		freetds-dev \
-		g++ \
 		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -47,8 +47,8 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list;
+	echo 'deb https://packagecloud.io/github/git-lfs/debian stretch main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list;
 
 # Additional packages
 RUN set -xe; \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -65,6 +65,7 @@ RUN set -xe; \
 		# html2text binary - used for self-testing (php-fpm)
 		html2text \
 		imagemagick \
+		iputils-ping \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
 		libfcgi-bin \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -84,7 +84,6 @@ RUN set -xe; \
 		supervisor \
 		unzip \
 		zip \
-		zsh \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -42,8 +42,6 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# backports repo
-	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
 	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -98,10 +98,10 @@ convert_secrets
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
 # To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
 # We apply a fix/workaround for this at startup (non-recursive).
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" /var/www
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 
 # Automatically authenticate with Pantheon in Terminus token is present
 # Note: this has to happen after th home directory permissions are reset,

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -22,8 +22,9 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
-		ca-certificates \
-		curl \
+		# ca-certificates and curl come from upstream
+		#ca-certificates \
+		#curl \
 		gnupg \
 		locales \
 		wget \
@@ -123,8 +124,9 @@ ENV NOTVISIBLE "in users profile"
 
 # PHP
 RUN set -xe; \
+	# Note: essential build tools (g++, gcc, make, etc) are included upstream as persistent packages.
+	# See https://github.com/docker-library/php/blob/4af0a8734a48ab84ee96de513aabc45418b63dc5/7.2/stretch/fpm/Dockerfile#L18-L37
 	buildDeps=" \
-		g++ \
 		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -87,7 +87,6 @@ RUN set -xe; \
 		supervisor \
 		unzip \
 		zip \
-		zsh \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -63,6 +63,7 @@ RUN set -xe; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
+		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -87,8 +88,6 @@ RUN set -xe; \
 		zip \
 		zsh \
 	;\
-	# More recent version of git to get composer's git cache.
-	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -68,6 +68,7 @@ RUN set -xe; \
 		# html2text binary - used for self-testing (php-fpm)
 		html2text \
 		imagemagick \
+		iputils-ping \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
 		libfcgi-bin \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
-	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
+	echo 'deb https://packages.microsoft.com/debian/9/prod stretch main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -47,8 +47,8 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian stretch main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -42,8 +42,6 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# backports repo
-	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
 	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -98,10 +98,10 @@ convert_secrets
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
 # To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
 # We apply a fix/workaround for this at startup (non-recursive).
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" /var/www
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 
 # Automatically authenticate with Pantheon in Terminus token is present
 # Note: this has to happen after th home directory permissions are reset,

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -22,8 +22,9 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
-		ca-certificates \
-		curl \
+		# ca-certificates and curl come from upstream
+		#ca-certificates \
+		#curl \
 		gnupg \
 		locales \
 		wget \
@@ -123,8 +124,9 @@ ENV NOTVISIBLE "in users profile"
 
 # PHP
 RUN set -xe; \
+	# Note: essential build tools (g++, gcc, make, etc) are included upstream as persistent packages.
+	# See https://github.com/docker-library/php/blob/4af0a8734a48ab84ee96de513aabc45418b63dc5/7.2/stretch/fpm/Dockerfile#L18-L37
 	buildDeps=" \
-		g++ \
 		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -87,7 +87,6 @@ RUN set -xe; \
 		supervisor \
 		unzip \
 		zip \
-		zsh \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -63,6 +63,7 @@ RUN set -xe; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
+		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -87,8 +88,6 @@ RUN set -xe; \
 		zip \
 		zsh \
 	;\
-	# More recent version of git to get composer's git cache.
-	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -68,6 +68,7 @@ RUN set -xe; \
 		# html2text binary - used for self-testing (php-fpm)
 		html2text \
 		imagemagick \
+		iputils-ping \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
 		libfcgi-bin \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
-	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
+	echo 'deb https://packages.microsoft.com/debian/9/prod stretch main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -47,8 +47,8 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian stretch main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -42,8 +42,6 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# backports repo
-	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
 	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -98,10 +98,10 @@ convert_secrets
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
 # To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
 # We apply a fix/workaround for this at startup (non-recursive).
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" /var/www
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 
 # Automatically authenticate with Pantheon in Terminus token is present
 # Note: this has to happen after th home directory permissions are reset,

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -22,8 +22,9 @@ RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		apt-transport-https \
-		ca-certificates \
-		curl \
+		# ca-certificates and curl come from upstream
+		#ca-certificates \
+		#curl \
 		gnupg \
 		locales \
 		wget \
@@ -123,8 +124,9 @@ ENV NOTVISIBLE "in users profile"
 
 # PHP
 RUN set -xe; \
+	# Note: essential build tools (g++, gcc, make, etc) are included upstream as persistent packages.
+	# See https://github.com/docker-library/php/blob/4af0a8734a48ab84ee96de513aabc45418b63dc5/7.2/stretch/fpm/Dockerfile#L18-L37
 	buildDeps=" \
-		g++ \
 		libc-client2007e-dev \
 		libfreetype6-dev \
 		libgpgme11-dev \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -87,7 +87,6 @@ RUN set -xe; \
 		supervisor \
 		unzip \
 		zip \
-		zsh \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -63,6 +63,7 @@ RUN set -xe; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		cron \
 		dnsutils \
+		git \
 		git-lfs \
 		ghostscript \
 		# html2text binary - used for self-testing (php-fpm)
@@ -87,8 +88,6 @@ RUN set -xe; \
 		zip \
 		zsh \
 	;\
-	# More recent version of git to get composer's git cache.
-	apt-get -y --no-install-recommends -t jessie-backports install git >/dev/null ;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -68,6 +68,7 @@ RUN set -xe; \
 		# html2text binary - used for self-testing (php-fpm)
 		html2text \
 		imagemagick \
+		iputils-ping \
 		less \
 		# cgi-fcgi binary - used for self-testing (php-fpm)
 		libfcgi-bin \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
 	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
-	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;
+	echo 'deb https://packages.microsoft.com/debian/9/prod stretch main' | tee /etc/apt/sources.list.d/mssql.list;
 
 # Additional packages
 RUN set -xe; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -47,8 +47,8 @@ RUN set -xe; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
 	# git-lfs repo
 	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
-	echo 'deb https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
-	echo 'deb-src https://packagecloud.io/github/git-lfs/debian/ jessie main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian stretch main' | tee /etc/apt/sources.list.d/github_git-lfs.list; \
+	echo 'deb-src https://packagecloud.io/github/git-lfs/debian stretch main' | tee -a /etc/apt/sources.list.d/github_git-lfs.list; \
 	# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
 	curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
 	echo 'deb https://packages.microsoft.com/debian/8/prod jessie main' | tee /etc/apt/sources.list.d/mssql.list;

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -42,8 +42,6 @@ ENV LC_ALL C.UTF-8
 # Enable additional repos
 RUN set -xe; \
 	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
-	# backports repo
-	echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/backports.list; \
 	# blackfire.io repo
 	curl -fsSL https://packagecloud.io/gpg.key | apt-key add -; \
 	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -98,10 +98,10 @@ convert_secrets
 # Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
 # To not bloat the image size, permissions on the home folder are reset at runtime.
 echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
 # Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
 # We apply a fix/workaround for this at startup (non-recursive).
-chown "${HOST_UID-:1000}:${HOST_GID:-1000}" /var/www
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 
 # Automatically authenticate with Pantheon in Terminus token is present
 # Note: this has to happen after th home directory permissions are reset,

--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # CLI Docker image for Docksal
 
-This image is focused on console tools necessary to develop LAMP stack applications.
+This image is focused on console tools necessary to develop LAMP stack (and other web) applications.
 
 This image(s) is part of the [Docksal](http://docksal.io) image library.
+
+
+## Features
+
+- php/php-fpm (w/ xdebug), nodejs (via nvm), phyton, ruby
+- Framework specific tools for Drupal, Wordpress, Magento
+- Miscellaneous cli tools for day to day web development
+- Hosting provider cli tools (Acquia, Pantheon, Platform.sh)
+- Cron job scheduling
+- Custom startup script support
+- Web based IDE (Cloud9)
 
 
 ## Versions and image tag naming convention
 
 - Stable versions
-  - `2.0-php5.6`, `php5.6` - PHP 5.6
-  - `2.0-php7.0`, `php7.0` - PHP 7.0
-  - `2.0-php7.1`, `php7.1` - PHP 7.1
-  - `2.0-php7.2`, `php7.2`, `latest` - PHP 7.2
+  - `2.3-php5.6`, `php5.6` - PHP 5.6
+  - `2.3-php7.0`, `php7.0` - PHP 7.0
+  - `2.3-php7.1`, `php7.1` - PHP 7.1
+  - `2.3-php7.2`, `php7.2`, `latest` - PHP 7.2
 - Development versions
   - `edge-php5.6` - PHP 5.6
   - `edge-php7.0` - PHP 7.0
@@ -19,42 +30,73 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
   - `edge-php7.2` - PHP 7.2
 
 
-## Includes
+## Supported languages and tools
 
-- php
-  - php-fpm && php-cli
-  - xdebug
-  - composer
-  - drush
-    - registry_rebuild
-    - coder-8.x + phpcs
-    - Acquia Cloud API commands
-  - drupal console launcher
-  - terminus (Pantheon)
-  - platform (Platform.sh)
-  - wp-cli
-- ruby
-  - ruby
-  - gem
-  - bundler
-- nodejs
-  - nodejs
-  - npm, yarn
+### PHP
+
+- php-fpm && php-cli
+- xdebug
+- composer
+- drush (Drupal)
+  - drush launcher with a fallback to a global drush 8 
+  - registry_rebuild module
+  - coder-8.x + phpcs
+- drupal console launcher (Drupal)
+- wp-cli (Wordpress)
+- mg2-codegen (Magento 2)
+
+This image uses the official `php-fpm` images from [Docker Hub](https://hub.docker.com/_/php/) as the base.  
+This means that PHP and all modules are installed from source. Extra modules have to be installed in the same
+manner (installing them with `apt-get` won't work).
+
+### NodeJS
+
+- nvm
+- node
+- npm
+- yarn
+
+NodeJS is installed via `nvm` in the docker user's profile inside the image (`/home/docker/.nvm`).
+
+This image follows the LTS release cycle for NodeJS, e.g.:
+
+    Latest LTS Version: 8.11.3 (includes npm 5.6.0)
+    Latest Current Version: 10.7.0 (includes npm 6.1.0) 
+
+If you need a different version of node, use `nvm` to install it, e.g, `nvm install 10.7.0`.
+
+Then `nvm use 10.7.0` to use it in the current session or `nvm alias default 10.7.0` to use it by default. 
+
+### Python
+
 - python
-- cron
 
-Other notable tools:
+### Ruby 
 
-- git
-- curl/wget
-- zip/unzip
-- mysql-client
+- ruby
+- gem
+- bundler
+
+### Other notable tools
+
+- git with git-lfs
+- curl, wget
+- zip, unzip
+- mysql, pgsql and mssql cli clients
 - imagemagick
 - mc
 - mhsendmail
+- cron
 
+### Hosting provider tools
 
-## PHP database drivers support
+- Acquia Cloud API drush commands ([Acquia](https://www.acquia.com/)) 
+- terminus ([Pantheon](https://pantheon.io/))
+- platform ([Platform.sh](https://platform.sh/))
+
+Also, see the [Secrets](#secrets) section below for more information on managing and using your hosting provider keys.
+
+## Available PHP database drivers
 
 - SQLite - via `sqlite3`, `pdo_sqlite`
 - MySQL - via `mysqli`, `mysqlnd`, `pdo_mysql`
@@ -62,7 +104,7 @@ Other notable tools:
 - MSSQL - via `mssql` and `pdo_dblib` for PHP 5.6; `sqlsrv` and `pdo_sqlsrv` for PHP 7.0+
 
 
-## Xdebug
+## Using PHP Xdebug
 
 Xdebug is disabled by default.
 
@@ -79,17 +121,21 @@ cli
 
 [See docs](https://docs.docksal.io/en/master/tools/xdebug) on using Xdebug for web and cli PHP debugging.
 
-## Customizing Startup
+
+## Customizing startup
 
 To run a custom startup script anytime the `cli` container has started, create a `startup.sh` file within the
 `.docksal/services/cli` directory. Additionally, make sure that the file is executable as well so that the container
 does not run into issues when attempting to execute the file.
 
-## Customized Cron Configuration
+
+## Scheduling cron jobs
 
 Cron can be configured by making sure there is a `crontab` file located within `.docksal/services/cli`. The file should
 follow the [standard crontab format](http://www.nncron.ru/help/EN/working/cron-format.htm).
 
+
+<a name="secrets"></a>
 ## Secrets and integrations
 
 `cli` can read secrets from environment variables and configure the respective integrations automatically at start.  
@@ -125,3 +171,20 @@ Credentials used to authenticate with the [Platform.sh CLI](https://github.com/p
 Stored in `/home/docker/.platform` inside `cli`.
 
 Platform CLI is installed and available globally in `cli`.
+
+
+<a name="ide"></a>
+## Web based IDE (Cloud9)
+
+[Cloud9](https://c9.github.io/core/) is a free, open-source online IDE.
+
+Starting with version 2.3, there is the `ide` flavor of the images, which comes with Cloud9 pre-installed, e.g.:
+
+```
+2.3-php5.6-ide
+2.3-php7.0-ide
+2.3-php7.1-ide
+2.3-php7.2-ide
+``` 
+
+[See docs](https://docs.docksal.io/en/master/tools/cloud9/) for using Cloud 9 in Docksal.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This image(s) is part of the [Docksal](http://docksal.io) image library.
 ## Versions and image tag naming convention
 
 - Stable versions
-  - `2.3-php5.6`, `php5.6` - PHP 5.6
-  - `2.3-php7.0`, `php7.0` - PHP 7.0
-  - `2.3-php7.1`, `php7.1` - PHP 7.1
-  - `2.3-php7.2`, `php7.2`, `latest` - PHP 7.2
+  - `2.4-php5.6`, `php5.6` - PHP 5.6
+  - `2.4-php7.0`, `php7.0` - PHP 7.0
+  - `2.4-php7.1`, `php7.1` - PHP 7.1
+  - `2.4-php7.2`, `php7.2`, `latest` - PHP 7.2
 - Development versions
   - `edge-php5.6` - PHP 5.6
   - `edge-php7.0` - PHP 7.0
@@ -181,10 +181,10 @@ Platform CLI is installed and available globally in `cli`.
 Starting with version 2.3, there is the `ide` flavor of the images, which comes with Cloud9 pre-installed, e.g.:
 
 ```
-2.3-php5.6-ide
-2.3-php7.0-ide
-2.3-php7.1-ide
-2.3-php7.2-ide
+2.4-php5.6-ide
+2.4-php7.0-ide
+2.4-php7.1-ide
+2.4-php7.2-ide
 ``` 
 
 [See docs](https://docs.docksal.io/en/master/tools/cloud9/) for using Cloud 9 in Docksal.

--- a/cloud9/Dockerfile
+++ b/cloud9/Dockerfile
@@ -15,13 +15,8 @@ RUN \
 	# Always source user profile when provisioning as user (necessary for nvm/etc. to load)
 	. $HOME/.profile; \
 	set -xe; \
-	buildDeps=" \
-		g++ \
-		make \
-	";\
 	sudo apt-get update; \
 	sudo apt-get -y --no-install-recommends install >/dev/null \
-		$buildDeps \
 		tmux \
 	;\
 	\

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -65,6 +65,53 @@ _healthcheck_wait ()
 # To work on a specific test:
 # run `export SKIP=1` locally, then comment skip in the test you want to debug
 
+@test "Essential binaries" {
+	#[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	make start
+	_healthcheck_wait
+
+	### Tests ###
+
+	# List of binaries to check
+	binaries='\
+		cat \
+		convert \
+		curl \
+		dig \
+		g++ \
+		ghostscript \
+		git \
+		git-lfs \
+		gcc \
+		html2text \
+		less \
+		make \
+		mc \
+		more \
+		mysql \
+		nano \
+		nslookup \
+		ping \
+		psql \
+		pv \
+		rsync \
+		sudo \
+		unzip \
+		wget \
+		zip \
+	'
+
+	# Check all binaries in a single shot
+	run make exec -e CMD="type $(echo ${binaries} | xargs)"
+	[[ ${status} == 0 ]]
+	unset output
+
+	### Cleanup ###
+	make clean
+}
+
 @test "Bare service" {
 	[[ $SKIP == 1 ]] && skip
 
@@ -206,7 +253,7 @@ _healthcheck_wait ()
 }
 
 @test "Check NodeJS tools and versions" {
-	#[[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	### Setup ###
 	make start

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -66,7 +66,7 @@ _healthcheck_wait ()
 # run `export SKIP=1` locally, then comment skip in the test you want to debug
 
 @test "Essential binaries" {
-	#[[ $SKIP == 1 ]] && skip
+	[[ $SKIP == 1 ]] && skip
 
 	### Setup ###
 	make start
@@ -445,8 +445,8 @@ _healthcheck_wait ()
 	[[ "${output}" == "" ]]
 	unset output
 
-	# Sleep for 60 seconds so cron can run again.
-	sleep 60
+	# Sleep for 60+1 seconds so cron can run again.
+	sleep 61
 
 	# Confirm cron has ran and file contents has changed
 	run docker exec -u docker "$NAME" bash -lc 'tail -1 /tmp/date.txt'


### PR DESCRIPTION
- Added `ping` utility
- Removed the git version override
  - Debian Stretch ships with git v2.11.0, so the override introduced in #25 is no longer necessary.
- Switched `mssql` and `git-lfs` repos from `jessie` to `stretch`
- Removed packages installed upstream as persistent
  - `ca-certificates`, `curl`
  - `g++` - we've been considering this a build dependency only, so it was uninstalled at the end of the build. This closes docksal/docksal#713.
- Removed `zsh` (not used)
- Fixed a typo in `chown` in `startup.sh`
- Added tests for essential binaries
- Updated README.md
