### PR TITLE
Add APCu pecl extension. Fixes #75

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -202,6 +202,8 @@ RUN set -xe; \
 		ssh2 \
 		# xdebug-2.5.5 is the last version with php5 support
 		xdebug-2.5.5 \
+		# apcu-4.0.11 is the last version with php5 support
+		apcu-4.0.11 \
 	;\
 	docker-php-ext-enable \
 		gnupg \
@@ -209,6 +211,7 @@ RUN set -xe; \
 		memcache \
 		redis \
 		ssh2 \
+		apcu \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -209,6 +209,7 @@ RUN set -xe; \
 		redis \
 		sqlsrv \
 		xdebug \
+		apcu \
 	;\
 	docker-php-ext-enable \
 		gnupg \
@@ -217,6 +218,7 @@ RUN set -xe; \
 		pdo_sqlsrv \
 		redis \
 		sqlsrv \
+		apcu \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -209,6 +209,7 @@ RUN set -xe; \
 		redis \
 		sqlsrv \
 		xdebug \
+		apcu \
 	;\
 	docker-php-ext-enable \
 		gnupg \
@@ -217,6 +218,7 @@ RUN set -xe; \
 		pdo_sqlsrv \
 		redis \
 		sqlsrv \
+		apcu \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -211,6 +211,7 @@ RUN set -xe; \
 		pdo_sqlsrv \
 		redis \
 		sqlsrv \
+		apcu \
 	;\
 	docker-php-ext-enable \
 		gnupg \
@@ -219,6 +220,7 @@ RUN set -xe; \
 		pdo_sqlsrv \
 		redis \
 		sqlsrv \
+		apcu \
 	;\
 	# Disable xdebug by default
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \


### PR DESCRIPTION
Issue: https://github.com/docksal/service-cli/issues/75

We've faced the same issue and extended container to have APCu installed by default. Here is a patch for all PHP 7 versions. 