### PR TITLE
Adjusted PHPCS location

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -280,7 +280,7 @@ RUN set -xe; \
 	composer global require hirak/prestissimo >/dev/null; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	phpcs --config-set installed_paths $HOME/.composer/global/drupal/coder/vendor/drupal/coder/coder_sniffer; \
 	# Magento2 Code Generator
 	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -287,7 +287,7 @@ RUN set -xe; \
 	composer global require hirak/prestissimo >/dev/null; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	phpcs --config-set installed_paths $HOME/.composer/global/drupal/coder/vendor/drupal/coder/coder_sniffer; \
 	# Magento2 Code Generator
 	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -287,7 +287,7 @@ RUN set -xe; \
 	composer global require hirak/prestissimo >/dev/null; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	phpcs --config-set installed_paths $HOME/.composer/global/drupal/coder/vendor/drupal/coder/coder_sniffer; \
 	# Magento2 Code Generator
 	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -289,7 +289,7 @@ RUN set -xe; \
 	composer global require hirak/prestissimo >/dev/null; \
 	# Drupal Coder w/ a matching version of PHP_CodeSniffer
 	cgr drupal/coder >/dev/null; \
-	phpcs --config-set installed_paths $HOME/.composer/vendor/drupal/coder/coder_sniffer; \
+	phpcs --config-set installed_paths $HOME/.composer/global/drupal/coder/vendor/drupal/coder/coder_sniffer; \
 	# Magento2 Code Generator
 	cgr staempfli/magento2-code-generator:${MG_CODEGEN_VERSION} >/dev/null; \
 	# Terminus


### PR DESCRIPTION
Adjusted location of Drupal Coder Location.

Because PHPCS is installed using CGR. CGR puts the packages in `$HOME/.composer/global/...` and PHPCS has a hard time finding standards in the old path.