### PR TITLE
Added BackDrop Command

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -265,7 +265,7 @@ USER docker
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
 	TERMINUS_VERSION=1.9.0 \
-	BACKDROP_DRUSH=0.0.6
+	DRUSH_BACKDROP_VERSION=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -291,7 +291,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${DRUSH_BACKDROP_VERSION}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -264,7 +264,8 @@ USER docker
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
-	TERMINUS_VERSION=1.9.0
+	TERMINUS_VERSION=1.9.0 \
+	BACKDROP_DRUSH=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -290,6 +291,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -271,7 +271,8 @@ USER docker
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
-	TERMINUS_VERSION=1.9.0
+	TERMINUS_VERSION=1.9.0 \
+	BACKDROP_DRUSH=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -297,6 +298,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -272,7 +272,7 @@ USER docker
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
 	TERMINUS_VERSION=1.9.0 \
-	BACKDROP_DRUSH=0.0.6
+	DRUSH_BACKDROP_VERSION=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -298,7 +298,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${DRUSH_BACKDROP_VERSION}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -271,7 +271,8 @@ USER docker
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
-	TERMINUS_VERSION=1.9.0
+	TERMINUS_VERSION=1.9.0 \
+	BACKDROP_DRUSH=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -297,6 +298,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -272,7 +272,7 @@ USER docker
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
 	TERMINUS_VERSION=1.9.0 \
-	BACKDROP_DRUSH=0.0.6
+	DRUSH_BACKDROP_VERSION=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -298,7 +298,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${DRUSH_BACKDROP_VERSION}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -273,7 +273,8 @@ USER docker
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
-	TERMINUS_VERSION=1.9.0
+	TERMINUS_VERSION=1.9.0 \
+	BACKDROP_DRUSH=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -299,6 +300,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -274,7 +274,7 @@ USER docker
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.10.2 \
 	TERMINUS_VERSION=1.9.0 \
-	BACKDROP_DRUSH=0.0.6
+	DRUSH_BACKDROP_VERSION=0.0.6
 RUN set -xe; \
 	\
 	# Set drush8 as a global fallback for Drush Launcher
@@ -300,7 +300,7 @@ RUN set -xe; \
 	\
 	# Drush modules
 	drush dl registry_rebuild --default-major=7 --destination=$HOME/.drush >/dev/null; \
-	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${BACKDROP_DRUSH}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
+	mkdir $HOME/.drush/backdrop && curl -fsSL "https://github.com/backdrop-contrib/drush/archive/${DRUSH_BACKDROP_VERSION}.tar.gz" | tar xz -C $HOME/.drush/backdrop --strip-components 1; \
 	drush cc drush
 
 # Node.js (installed as user)

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -528,7 +528,7 @@ _healthcheck_wait ()
 
 	### Tests ###
 
-	# Check PHPCS libraries loaded
+	# Check Drush Backdrop command loaded
 	run docker exec -u docker "$NAME" bash -lc 'drush help backdrop-core-status'
 	[[ "${output}" =~ "Provides a birds-eye view of the current Backdrop installation, if any." ]]
 	unset output

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -518,3 +518,21 @@ _healthcheck_wait ()
 	### Cleanup ###
 	make clean
 }
+
+@test "Check Drush Backdrop Commands" {
+	[[ $SKIP == 1 ]] && skip
+
+	### Setup ###
+	make start
+	_healthcheck_wait
+
+	### Tests ###
+
+	# Check PHPCS libraries loaded
+	run docker exec -u docker "$NAME" bash -lc 'drush help backdrop-core-status'
+	[[ "${output}" =~ "Provides a birds-eye view of the current Backdrop installation, if any." ]]
+	unset output
+
+	### Cleanup ###
+	make clean
+}


### PR DESCRIPTION
Regular Drush doesn't work 100% with Backdrop therefore requires that drush have custom commands installed so that drush can be used with Backdrop.

https://backdropcms.org/project/drush