### PR TITLE
Run custom startup.sh script as the docker user

### DIFF
--- a/5.6/startup.sh
+++ b/5.6/startup.sh
@@ -154,7 +154,7 @@ touch /var/run/cli
 if [[ -x ${PROJECT_ROOT}/.docksal/services/cli/startup.sh ]]; then
 	echo-debug "Running custom startup script..."
 	# TODO: should we source the script instead?
-	${PROJECT_ROOT}/.docksal/services/cli/startup.sh
+	su -l docker -c "${PROJECT_ROOT}/.docksal/services/cli/startup.sh"
 	if [[ $? == 0 ]]; then
 		echo-debug "Custom startup script executed successfully."
 	else

--- a/7.0/startup.sh
+++ b/7.0/startup.sh
@@ -154,7 +154,7 @@ touch /var/run/cli
 if [[ -x ${PROJECT_ROOT}/.docksal/services/cli/startup.sh ]]; then
 	echo-debug "Running custom startup script..."
 	# TODO: should we source the script instead?
-	${PROJECT_ROOT}/.docksal/services/cli/startup.sh
+	su -l docker -c "${PROJECT_ROOT}/.docksal/services/cli/startup.sh"
 	if [[ $? == 0 ]]; then
 		echo-debug "Custom startup script executed successfully."
 	else

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -154,7 +154,7 @@ touch /var/run/cli
 if [[ -x ${PROJECT_ROOT}/.docksal/services/cli/startup.sh ]]; then
 	echo-debug "Running custom startup script..."
 	# TODO: should we source the script instead?
-	${PROJECT_ROOT}/.docksal/services/cli/startup.sh
+	su -l docker -c "${PROJECT_ROOT}/.docksal/services/cli/startup.sh"
 	if [[ $? == 0 ]]; then
 		echo-debug "Custom startup script executed successfully."
 	else

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -154,7 +154,7 @@ touch /var/run/cli
 if [[ -x ${PROJECT_ROOT}/.docksal/services/cli/startup.sh ]]; then
 	echo-debug "Running custom startup script..."
 	# TODO: should we source the script instead?
-	${PROJECT_ROOT}/.docksal/services/cli/startup.sh
+	su -l docker -c "${PROJECT_ROOT}/.docksal/services/cli/startup.sh"
 	if [[ $? == 0 ]]; then
 		echo-debug "Custom startup script executed successfully."
 	else

--- a/tests/.docksal/services/cli/startup.sh
+++ b/tests/.docksal/services/cli/startup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 echo "I ran properly" > /tmp/test-startup.txt
+which terminus > /tmp/test-startup-terminus.txt

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -341,6 +341,10 @@ _healthcheck_wait ()
 	[[ ${status} == 0 ]]
 	[[ "${output}" =~ "I ran properly" ]]
 
+	run docker exec -u docker "${NAME}" cat /tmp/test-startup-terminus.txt
+	[[ ${status} == 0 ]]
+	[[ "${output}" =~ "/home/docker/.composer/vendor/bin/terminus" ]]
+
 	### Cleanup ###
 	make clean
 }


### PR DESCRIPTION
The custom startup script doesn't run a the docker user therefore doesn't have access to any of the variables and doesn't have access to any of the items in `$PATH`.

Suggesting changing to run the script as `docker`.