### PR TITLE
Fixed TTY issue with GPG key import

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -304,7 +304,7 @@ ENV \
 	RUBY_VERSION=2.5.3
 
 RUN set -xe; \
-        curl -sSL https://rvm.io/mpapis.asc | gpg --import -; \
+        curl -sSL https://rvm.io/mpapis.asc | gpg --no-tty --import -; \
 	curl -fsSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer | bash -s -- --version ${RVM_VERSION}; \
         bash -lc 'rvm install ruby-${RUBY_VERSION}'; \
 	# Have bundler install gems locally (./.bundle) by default

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -311,7 +311,7 @@ ENV \
 	RUBY_VERSION=2.5.3
 
 RUN set -xe; \
-        curl -sSL https://rvm.io/mpapis.asc | gpg --import -; \
+        curl -sSL https://rvm.io/mpapis.asc | gpg --no-tty --import -; \
 	curl -fsSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer | bash -s -- --version ${RVM_VERSION}; \
         bash -lc 'rvm install ruby-${RUBY_VERSION}'; \
 	# Have bundler install gems locally (./.bundle) by default

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -311,7 +311,7 @@ ENV \
 	RUBY_VERSION=2.5.3
 
 RUN set -xe; \
-        curl -sSL https://rvm.io/mpapis.asc | gpg --import -; \
+        curl -sSL https://rvm.io/mpapis.asc | gpg --no-tty --import -; \
 	curl -fsSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer | bash -s -- --version ${RVM_VERSION}; \
         bash -lc 'rvm install ruby-${RUBY_VERSION}'; \
 	# Have bundler install gems locally (./.bundle) by default

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -313,7 +313,7 @@ ENV \
 	RUBY_VERSION=2.5.3
 
 RUN set -xe; \
-        curl -sSL https://rvm.io/mpapis.asc | gpg --import -; \
+        curl -sSL https://rvm.io/mpapis.asc | gpg --no-tty --import -; \
 	curl -fsSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION}/binscripts/rvm-installer | bash -s -- --version ${RVM_VERSION}; \
         bash -lc 'rvm install ruby-${RUBY_VERSION}'; \
 	# Have bundler install gems locally (./.bundle) by default


### PR DESCRIPTION
Fixing issue to make the GPG key import issue that is happening on builds.

```
gpg: cannot open '/dev/tty': No such device or address
```