### PR TITLE
Added --read-envelope-from option for msmtp

### DIFF
--- a/5.6/config/php/zz-php.ini
+++ b/5.6/config/php/zz-php.ini
@@ -11,7 +11,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
 
 ; Extention settings
 [opcache]

--- a/7.0/config/php/zz-php.ini
+++ b/7.0/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
 
 ; Extention settings
 [opcache]

--- a/7.1/config/php/zz-php.ini
+++ b/7.1/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
 
 ; Extention settings
 [opcache]

--- a/7.2/config/php/zz-php.ini
+++ b/7.2/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
 
 ; Extention settings
 [opcache]

--- a/7.3/config/php/zz-php.ini
+++ b/7.3/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
 
 ; Extention settings
 [opcache]


### PR DESCRIPTION
Added `--read-envelope-from` option to the sendmail_path in php.ini to resolve "envelope-from address is missing" errors (see https://github.com/docksal/service-cli/issues/116)