### PR TITLE
Use Debian Stretch as previous versions have been archived.

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.1-fpm-stretch
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.2-fpm-stretch
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm
+FROM php:7.3-fpm-stretch
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1


### PR DESCRIPTION
If you install Debian packages via .docksal/cli/Dockerfile, this will cause your build to fail because the Debian Jessie repositories have been archived. This update to using the latest version, Debian Stretch.

https://unix.stackexchange.com/questions/508724/failed-to-fetch-jessie-backports-repository

https://gitter.im/docksal/community-support?at=5c9b8edb6a3d2e230d33e566