### PR TITLE
Create docker group as part of `useradd` command

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -77,8 +77,7 @@ RUN set -xe; \
 
 RUN set -xe; \
 	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
-	groupadd docker -g 1000; \
-	useradd -m -s /bin/bash -u 1000 -g 1000 -p docker docker; \
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
 	# Give the docker user sudo access
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -81,8 +81,7 @@ RUN set -xe; \
 
 RUN set -xe; \
 	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
-	groupadd docker -g 1000; \
-	useradd -m -s /bin/bash -u 1000 -g 1000 -p docker docker; \
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
 	# Give the docker user sudo access
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -81,8 +81,7 @@ RUN set -xe; \
 
 RUN set -xe; \
 	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
-	groupadd docker -g 1000; \
-	useradd -m -s /bin/bash -u 1000 -g 1000 -p docker docker; \
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
 	# Give the docker user sudo access
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -81,8 +81,7 @@ RUN set -xe; \
 
 RUN set -xe; \
 	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
-	groupadd docker -g 1000; \
-	useradd -m -s /bin/bash -u 1000 -g 1000 -p docker docker; \
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
 	# Give the docker user sudo access
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -81,8 +81,7 @@ RUN set -xe; \
 
 RUN set -xe; \
 	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
-	groupadd docker -g 1000; \
-	useradd -m -s /bin/bash -u 1000 -g 1000 -p docker docker; \
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
 	# Give the docker user sudo access
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
The -U flag has been a part of shadow [since 4.1.1](https://github.com/shadow-maint/shadow/commit/93e2f66a60). It tries to create a group with the same name and ID as the user (but will potentially use a higher group ID if the user ID is not available as a group ID).

Since the UID is already specified with the `-u` flag, we do not need to specify `1000` a second time for the group or preface `useradd` with `groupadd`.