### PR TITLE
Updated versions for cli tools

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -234,8 +234,8 @@ ENV COMPOSER_VERSION=1.9.0 \
 	DRUPAL_CHECK_VERSION=1.0.13 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.3 \
 	WPCLI_VERSION=2.3.0 \
-	BLACKFIRE_VERSION=1.22.0 \
-	PLATFORMSH_CLI_VERSION=3.47.0
+	BLACKFIRE_VERSION=1.27.4 \
+	PLATFORMSH_CLI_VERSION=3.49.1
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -262,7 +262,7 @@ SHELL ["/bin/bash", "-c"]
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.11.0 \
-	TERMINUS_VERSION=2.1.0 \
+	TERMINUS_VERSION=2.2.0 \
 	DRUSH_BACKDROP_VERSION=1.0.0
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
@@ -302,9 +302,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.34.0 \
-	NODE_VERSION=10.16.3 \
-	YARN_VERSION=1.17.3
+	NVM_VERSION=0.35.0 \
+	NODE_VERSION=12.13.0 \
+	YARN_VERSION=1.19.1
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -319,7 +319,7 @@ RUN set -e; \
 # Ruby (installed as user)
 ENV \
 	RVM_VERSION_INSTALL=1.29.9 \
-	RUBY_VERSION_INSTALL=2.6.4
+	RUBY_VERSION_INSTALL=2.6.5
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# Public GPG servers are not realiable, so downloading keys from rvm.io instead.
@@ -358,7 +358,7 @@ RUN set -e; \
 
 # Python (installed as user)
 ENV \
-	PYENV_VERSION_INSTALL=1.2.13
+	PYENV_VERSION_INSTALL=1.2.14
 #	PYTHON_VERSION_INSTALL=3.7.0
 RUN set -xe; \
 	git clone --depth 1 -b v${PYENV_VERSION_INSTALL} https://github.com/pyenv/pyenv.git $HOME/.pyenv; \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -232,8 +232,8 @@ ENV COMPOSER_VERSION=1.9.0 \
 	DRUPAL_CHECK_VERSION=1.0.13 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.3 \
 	WPCLI_VERSION=2.3.0 \
-	BLACKFIRE_VERSION=1.22.0 \
-	PLATFORMSH_CLI_VERSION=3.47.0
+	BLACKFIRE_VERSION=1.27.4 \
+	PLATFORMSH_CLI_VERSION=3.49.1
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -260,7 +260,7 @@ SHELL ["/bin/bash", "-c"]
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.11.0 \
-	TERMINUS_VERSION=2.1.0 \
+	TERMINUS_VERSION=2.2.0 \
 	DRUSH_BACKDROP_VERSION=1.0.0
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
@@ -300,9 +300,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.34.0 \
-	NODE_VERSION=10.16.3 \
-	YARN_VERSION=1.17.3
+	NVM_VERSION=0.35.0 \
+	NODE_VERSION=12.13.0 \
+	YARN_VERSION=1.19.1
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -317,7 +317,7 @@ RUN set -e; \
 # Ruby (installed as user)
 ENV \
 	RVM_VERSION_INSTALL=1.29.9 \
-	RUBY_VERSION_INSTALL=2.6.4
+	RUBY_VERSION_INSTALL=2.6.5
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# Public GPG servers are not realiable, so downloading keys from rvm.io instead.
@@ -356,7 +356,7 @@ RUN set -e; \
 
 # Python (installed as user)
 ENV \
-	PYENV_VERSION_INSTALL=1.2.13
+	PYENV_VERSION_INSTALL=1.2.14
 #	PYTHON_VERSION_INSTALL=3.7.0
 RUN set -xe; \
 	git clone --depth 1 -b v${PYENV_VERSION_INSTALL} https://github.com/pyenv/pyenv.git $HOME/.pyenv; \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -232,8 +232,8 @@ ENV COMPOSER_VERSION=1.9.0 \
 	DRUPAL_CHECK_VERSION=1.0.13 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.3 \
 	WPCLI_VERSION=2.3.0 \
-	BLACKFIRE_VERSION=1.22.0 \
-	PLATFORMSH_CLI_VERSION=3.47.0
+	BLACKFIRE_VERSION=1.27.4 \
+	PLATFORMSH_CLI_VERSION=3.49.1
 RUN set -xe; \
 	# Composer
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer; \
@@ -260,7 +260,7 @@ SHELL ["/bin/bash", "-c"]
 
 # PHP tools (installed as user)
 ENV MG_CODEGEN_VERSION=1.11.0 \
-	TERMINUS_VERSION=2.1.0 \
+	TERMINUS_VERSION=2.2.0 \
 	DRUSH_BACKDROP_VERSION=1.0.0
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
@@ -300,9 +300,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.34.0 \
-	NODE_VERSION=10.16.3 \
-	YARN_VERSION=1.17.3
+	NVM_VERSION=0.35.0 \
+	NODE_VERSION=12.13.0 \
+	YARN_VERSION=1.19.1
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -317,7 +317,7 @@ RUN set -e; \
 # Ruby (installed as user)
 ENV \
 	RVM_VERSION_INSTALL=1.29.9 \
-	RUBY_VERSION_INSTALL=2.6.4
+	RUBY_VERSION_INSTALL=2.6.5
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# Public GPG servers are not realiable, so downloading keys from rvm.io instead.
@@ -356,7 +356,7 @@ RUN set -e; \
 
 # Python (installed as user)
 ENV \
-	PYENV_VERSION_INSTALL=1.2.13
+	PYENV_VERSION_INSTALL=1.2.14
 #	PYTHON_VERSION_INSTALL=3.7.0
 RUN set -xe; \
 	git clone --depth 1 -b v${PYENV_VERSION_INSTALL} https://github.com/pyenv/pyenv.git $HOME/.pyenv; \


### PR DESCRIPTION
- Blackfire v1.27.4
- Platform.sh cli v3.49.1
- Terminus v2.2.0
- nvm v0.35.0 / nodejs v12.13.0 LTS / yarn v1.19.1
- Ruby v2.6.5
- pyenv v1.2.14