### PR TITLE
VS Code IDE password protection

### DIFF
--- a/7.1/opt/code-server/supervisord-code-server.conf
+++ b/7.1/opt/code-server/supervisord-code-server.conf
@@ -1,6 +1,6 @@
 # VS Code Server web IDE
 [program:code-server]
 # Using bash -lc here to load docker user profile (necessary for nvn/node to initialize)
-command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http'
+command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http {{ extra_options }}'
 stdout_logfile = /var/log/supervisor/code-server-stdout
 stderr_logfile = /var/log/supervisor/code-server-stderr

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -42,7 +42,6 @@ ide_mode_enable ()
 	fi
 	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
 	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
-	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }

--- a/7.1/startup.sh
+++ b/7.1/startup.sh
@@ -34,7 +34,15 @@ ide_mode_enable ()
 	# Enabled only code-server service (disabled all other services)
 	# TODO: [v3] split IDE/cli and php-fpm entirely
 	rm -f /etc/supervisor/conf.d/supervisord-*
-	ln -s /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	if [[ "$IDE_PASSWORD" != "" ]]; then
+		export PASSWORD="${IDE_PASSWORD}"
+		extra_options=""
+	else
+		extra_options="--no-auth"
+	fi
+	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
+	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }

--- a/7.2/opt/code-server/supervisord-code-server.conf
+++ b/7.2/opt/code-server/supervisord-code-server.conf
@@ -1,6 +1,6 @@
 # VS Code Server web IDE
 [program:code-server]
 # Using bash -lc here to load docker user profile (necessary for nvn/node to initialize)
-command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http'
+command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http {{ extra_options }}'
 stdout_logfile = /var/log/supervisor/code-server-stdout
 stderr_logfile = /var/log/supervisor/code-server-stderr

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -42,7 +42,6 @@ ide_mode_enable ()
 	fi
 	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
 	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
-	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }

--- a/7.2/startup.sh
+++ b/7.2/startup.sh
@@ -34,7 +34,15 @@ ide_mode_enable ()
 	# Enabled only code-server service (disabled all other services)
 	# TODO: [v3] split IDE/cli and php-fpm entirely
 	rm -f /etc/supervisor/conf.d/supervisord-*
-	ln -s /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	if [[ "$IDE_PASSWORD" != "" ]]; then
+		export PASSWORD="${IDE_PASSWORD}"
+		extra_options=""
+	else
+		extra_options="--no-auth"
+	fi
+	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
+	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }

--- a/7.3/opt/code-server/supervisord-code-server.conf
+++ b/7.3/opt/code-server/supervisord-code-server.conf
@@ -1,6 +1,6 @@
 # VS Code Server web IDE
 [program:code-server]
 # Using bash -lc here to load docker user profile (necessary for nvn/node to initialize)
-command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http'
+command = gosu docker bash -lc '/usr/local/bin/code-server --user-data-dir=/home/docker/code-server -p 8080 /var/www --allow-http {{ extra_options }}'
 stdout_logfile = /var/log/supervisor/code-server-stdout
 stderr_logfile = /var/log/supervisor/code-server-stderr

--- a/7.3/startup.sh
+++ b/7.3/startup.sh
@@ -42,7 +42,6 @@ ide_mode_enable ()
 	fi
 	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
 	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
-	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }

--- a/7.3/startup.sh
+++ b/7.3/startup.sh
@@ -34,7 +34,15 @@ ide_mode_enable ()
 	# Enabled only code-server service (disabled all other services)
 	# TODO: [v3] split IDE/cli and php-fpm entirely
 	rm -f /etc/supervisor/conf.d/supervisord-*
-	ln -s /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	if [[ "$IDE_PASSWORD" != "" ]]; then
+		export PASSWORD="${IDE_PASSWORD}"
+		extra_options=""
+	else
+		extra_options="--no-auth"
+	fi
+	cp /opt/code-server/supervisord-code-server.conf /etc/supervisor/conf.d/
+	sed -i 's/{{ extra_options }}/'${extra_options}'/g' /etc/supervisor/conf.d/supervisord-code-server.conf
+	cat /etc/supervisor/conf.d/supervisord-code-server.conf
 	mkdir -p ${VSCODE_HOME}/User
 	ln -s /opt/code-server/settings.json ${VSCODE_HOME}/User/
 }


### PR DESCRIPTION
Use IDE_PASSWORD env variable for setting VS code IDE password
with empty IDE_PASSWORD your IDE environment will be accessible without password