### PR TITLE
Removed --read-envelope-from in sendmail_path

### DIFF
--- a/7.1/config/php/zz-php.ini
+++ b/7.1/config/php/zz-php.ini
@@ -3,7 +3,6 @@
 [php]
 memory_limit = 1024M
 max_execution_time = 600
-sendmail_path = /bin/true
 date.timezone = UTC
 display_errors = On
 display_startup_errors = On

--- a/7.1/config/php/zz-php.ini
+++ b/7.1/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 
 ; Extention settings
 [opcache]

--- a/7.2/config/php/zz-php.ini
+++ b/7.2/config/php/zz-php.ini
@@ -3,7 +3,6 @@
 [php]
 memory_limit = 1024M
 max_execution_time = 600
-sendmail_path = /bin/true
 date.timezone = UTC
 display_errors = On
 display_startup_errors = On

--- a/7.2/config/php/zz-php.ini
+++ b/7.2/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 
 ; Extention settings
 [opcache]

--- a/7.3/config/php/zz-php.ini
+++ b/7.3/config/php/zz-php.ini
@@ -3,7 +3,6 @@
 [php]
 memory_limit = 1024M
 max_execution_time = 600
-sendmail_path = /bin/true
 date.timezone = UTC
 display_errors = On
 display_startup_errors = On

--- a/7.3/config/php/zz-php.ini
+++ b/7.3/config/php/zz-php.ini
@@ -10,7 +10,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 
 ; Extention settings
 [opcache]

--- a/tests/scripts/php-fpm.sh
+++ b/tests/scripts/php-fpm.sh
@@ -9,4 +9,5 @@ export REQUEST_METHOD=GET
 # This can be a nightmare to debug, since nbsp's are identical to spaces in a text editor.
 # Note: this sed does NOT work on Mac, so make sure it's only run inside a container.
 # See https://superuser.com/questions/517847/use-sed-to-replace-nbsp-160-hex-00a0-octal-240-non-breaking-space
-cgi-fcgi -bind -connect 127.0.0.1:9000 | html2text | sed 's/\xC2\xA0/ /g'
+# "-width 1024" prevents text wrapping for long values (e.g. sendmail_path)
+cgi-fcgi -bind -connect 127.0.0.1:9000 | html2text -width 1024 | sed 's/\xC2\xA0/ /g'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -135,9 +135,8 @@ _healthcheck_wait ()
 	echo "$output" | grep "256M => 256M"
 	unset output
 
-	# sendmail_path, being long, gets cut off. We check it a little bit differently below
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 => /usr/bin/msmtp -t --host=mail --port=1025'
 	unset output
 
 	run docker exec -u docker "$NAME" /var/www/scripts/php-fpm.sh nonsense.php
@@ -161,7 +160,7 @@ _healthcheck_wait ()
 	unset output
 
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 => /usr/bin/msmtp -t --host=mail --port=1025'
 	unset output
 
 	# Check PHP modules

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -137,7 +137,7 @@ _healthcheck_wait ()
 
 	# sendmail_path, being long, gets cut off. We check it a little bit differently below
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025'
 	unset output
 
 	run docker exec -u docker "$NAME" /var/www/scripts/php-fpm.sh nonsense.php
@@ -161,7 +161,7 @@ _healthcheck_wait ()
 	unset output
 
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 --read-envelope-from'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025'
 	unset output
 
 	# Check PHP modules


### PR DESCRIPTION
This fixes "msmtp: cannot use both --from and --read-envelope-from" with Drupal 8.

Fixes #142. Reverts #117 