### PR TITLE
Make the drupal-check binary executable

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -254,7 +254,7 @@ RUN set -xe; \
 	# Drupal Check CLI
 	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drupal-check drush8 drush drupal wp blackfire platform);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -252,7 +252,7 @@ RUN set -xe; \
 	# Drupal Check CLI
 	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drupal-check drush8 drush drupal wp blackfire platform);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -252,7 +252,7 @@ RUN set -xe; \
 	# Drupal Check CLI
 	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer drush8 drush drupal wp blackfire platform);
+	(cd /usr/local/bin && chmod +x composer drupal-check drush8 drush drupal wp blackfire platform);
 
 # All further RUN commands will run as the "docker" user
 USER docker


### PR DESCRIPTION
When `drupal-check` was added in #139 I forgot to make it executable. This fixes that.