### PR TITLE
Add sysvsem extension

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -197,6 +197,7 @@ RUN set -xe; \
 		ssh2 \
 		xsl \
 		zip \
+		sysvsem \
 	;\
 	pecl update-channels; \
 	pecl install >/dev/null </dev/null \

--- a/7.2/php-modules.txt
+++ b/7.2/php-modules.txt
@@ -52,6 +52,7 @@ sqlite3
 sqlsrv
 ssh2
 standard
+sysvsem
 tokenizer
 xml
 xmlreader

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -197,6 +197,7 @@ RUN set -xe; \
 		ssh2 \
 		xsl \
 		zip \
+		sysvsem \
 	;\
 	pecl update-channels; \
 	pecl install >/dev/null </dev/null \

--- a/7.3/php-modules.txt
+++ b/7.3/php-modules.txt
@@ -52,6 +52,7 @@ sqlite3
 sqlsrv
 ssh2
 standard
+sysvsem
 tokenizer
 xml
 xmlreader

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -193,6 +193,7 @@ RUN set -xe; \
 		ssh2 \
 		xsl \
 		zip \
+		sysvsem \
 	;\
 	pecl update-channels; \
 	pecl install >/dev/null </dev/null \

--- a/7.4/php-modules.txt
+++ b/7.4/php-modules.txt
@@ -52,6 +52,7 @@ sqlite3
 sqlsrv
 ssh2
 standard
+sysvsem
 tokenizer
 xml
 xmlreader


### PR DESCRIPTION
closes: https://github.com/docksal/service-cli/issues/171
at the moment, xdebug version 2.9.1 is being installed from pecl. so image rebuild will closes: https://github.com/docksal/service-cli/issues/164