### PR TITLE
Notify web container about started fin exec inside cli

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -377,7 +377,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
+RUN echo '(/opt/ping-web.sh &)' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]
@@ -389,6 +389,7 @@ COPY --chown=docker:docker config/.ssh /home/docker/.ssh
 COPY config/supervisor /etc/supervisor/conf.d
 COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
+COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
 # PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
 # TODO: For now, will just hardcoded a specific version available on https://github.com/php/php-src/
@@ -408,6 +409,8 @@ ENV \
 	# Default values for HOST_UID and HOST_GUI to match the default Ubuntu user. These are used in startup.sh
 	HOST_UID=1000 \
 	HOST_GID=1000 \
+	# Delay in seconds between pings web from cli, while running fin exec. 0 - disabled
+	WEB_KEEPALIVE=0 \
 	# xdebug disabled by default
 	XDEBUG_ENABLED=0 \
 	XHPROF_ENABLED=0 \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -377,7 +377,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -376,6 +376,9 @@ RUN set -xe; \
 #	pyenv install ${PYTHON_VERSION_INSTALL}; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
+# Notify web container about started fin exec
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+
 USER root
 SHELL ["/bin/sh", "-c"]
 

--- a/7.2/ping-web.sh
+++ b/7.2/ping-web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Notify web container about started fin exec
+if [[ "${WEB_KEEPALIVE}" != "0" ]] && [[ "${VIRTUAL_HOST}" != "" ]]
+then
+	while true
+	do
+		curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1
+		sleep ${WEB_KEEPALIVE}
+	done
+fi

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -377,7 +377,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
+RUN echo '(/opt/ping-web.sh &)' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]
@@ -389,6 +389,7 @@ COPY --chown=docker:docker config/.ssh /home/docker/.ssh
 COPY config/supervisor /etc/supervisor/conf.d
 COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
+COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
 # PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
 # TODO: For now, will just hardcoded a specific version available on https://github.com/php/php-src/
@@ -408,6 +409,8 @@ ENV \
 	# Default values for HOST_UID and HOST_GUI to match the default Ubuntu user. These are used in startup.sh
 	HOST_UID=1000 \
 	HOST_GID=1000 \
+	# Delay in seconds between pings web from cli, while running fin exec. 0 - disabled
+	WEB_KEEPALIVE=0 \
 	# xdebug disabled by default
 	XDEBUG_ENABLED=0 \
 	XHPROF_ENABLED=0 \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -377,7 +377,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -376,6 +376,9 @@ RUN set -xe; \
 #	pyenv install ${PYTHON_VERSION_INSTALL}; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
+# Notify web container about started fin exec
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+
 USER root
 SHELL ["/bin/sh", "-c"]
 

--- a/7.3/ping-web.sh
+++ b/7.3/ping-web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Notify web container about started fin exec
+if [[ "${WEB_KEEPALIVE}" != "0" ]] && [[ "${VIRTUAL_HOST}" != "" ]]
+then
+	while true
+	do
+		curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1
+		sleep ${WEB_KEEPALIVE}
+	done
+fi

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -373,7 +373,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
+RUN echo '(/opt/ping-web.sh &)' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]
@@ -385,6 +385,7 @@ COPY --chown=docker:docker config/.ssh /home/docker/.ssh
 COPY config/supervisor /etc/supervisor/conf.d
 COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
+COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
 # PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
 # TODO: For now, will just hardcoded a specific version available on https://github.com/php/php-src/
@@ -405,6 +406,8 @@ ENV \
 	# Default values for HOST_UID and HOST_GUI to match the default Ubuntu user. These are used in startup.sh
 	HOST_UID=1000 \
 	HOST_GID=1000 \
+	# Delay in seconds between pings web from cli, while running fin exec. 0 - disabled
+	WEB_KEEPALIVE=0 \
 	# xdebug disabled by default
 	XDEBUG_ENABLED=0 \
 	XHPROF_ENABLED=0 \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -373,7 +373,7 @@ RUN set -xe; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
 # Notify web container about started fin exec
-RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 60; done &)">/dev/null' >> $HOME/.profile
 
 USER root
 SHELL ["/bin/sh", "-c"]

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -372,6 +372,9 @@ RUN set -xe; \
 #	pyenv install ${PYTHON_VERSION_INSTALL}; \
 #	pyenv global ${PYTHON_VERSION_INSTALL}
 
+# Notify web container about started fin exec
+RUN echo 'bash -c "[[ \"${VIRTUAL_HOST}\" != \"\" ]] && (while true; do curl -s -m 2 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1; sleep 10; done &)">/dev/null' >> $HOME/.profile
+
 USER root
 SHELL ["/bin/sh", "-c"]
 

--- a/7.4/ping-web.sh
+++ b/7.4/ping-web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Notify web container about started fin exec
+if [[ "${WEB_KEEPALIVE}" != "0" ]] && [[ "${VIRTUAL_HOST}" != "" ]]
+then
+	while true
+	do
+		curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1
+		sleep ${WEB_KEEPALIVE}
+	done
+fi

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Stored in `/home/docker/.platform` inside `cli`.
 
 Platform CLI is installed and available globally in `cli`.
 
+`WEB_KEEPALIVE`
+
+Sets the delay in seconds between pings of the web container during execution `fin exec`. Setting this variable to non zero value prevents the project from stopping in cases of long `fin exec` and web container inactivity. Disabled by default (set to 0).
 
 ## Git configuration
 


### PR DESCRIPTION
Workaround for https://github.com/docksal/service-vhost-proxy/issues/43
while fin exec is running, background process periodically ping web container (adds new records to web container logs)