### PR TITLE
Release 2.13.0

### DIFF
--- a/.github/scripts/docker-tags.sh
+++ b/.github/scripts/docker-tags.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Generates docker images tags for the docker/build-push-action@v2 action depending on the branch/tag.
+
+declare -a IMAGE_TAGS
+
+# feature/* => sha-xxxxxxx
+# Note: disabled
+#if [[ "${GITHUB_REF}" =~ "refs/heads/feature/" ]]; then
+#	GIT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7) # Short SHA (7 characters)
+#	IMAGE_TAGS+=("${REPO}:sha-${GIT_SHA7}-php${VERSION}")
+#	IMAGE_TAGS+=("ghcr.io/${REPO}:sha-${GIT_SHA7}-php${VERSION}")
+#fi
+
+# develop => edge
+if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
+	IMAGE_TAGS+=("${REPO}:edge-php${VERSION}")
+	IMAGE_TAGS+=("ghcr.io/${REPO}:edge-php${VERSION}")
+fi
+
+# master => stable
+if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
+	IMAGE_TAGS+=("${REPO}:stable-php${VERSION}")
+	IMAGE_TAGS+=("ghcr.io/${REPO}:stable-php${VERSION}")
+fi
+
+# tags/v1.0.0 => 1.0
+if [[ "${GITHUB_REF}" =~ "refs/tags/" ]]; then
+	# Extract version parts from release tag
+	IFS='.' read -a ver_arr <<< "${GITHUB_REF#refs/tags/}"
+	VERSION_MAJOR=${ver_arr[0]#v*}  # 2.7.0 => "2"
+	VERSION_MINOR=${ver_arr[1]}  # "2.7.0" => "7"
+	IMAGE_TAGS+=("${REPO}:stable-php${VERSION}")
+	IMAGE_TAGS+=("${REPO}:${VERSION_MAJOR}-php${VERSION}")
+	IMAGE_TAGS+=("${REPO}:${VERSION_MAJOR}.${VERSION_MINOR}-php${VERSION}")
+	IMAGE_TAGS+=("ghcr.io/${REPO}:stable-php${VERSION}")
+	IMAGE_TAGS+=("ghcr.io/${REPO}:${VERSION_MAJOR}-php${VERSION}")
+	IMAGE_TAGS+=("ghcr.io/${REPO}:${VERSION_MAJOR}.${VERSION_MINOR}-php${VERSION}")
+fi
+
+# Output a comma concatenated list of image tags
+IMAGE_TAGS_STR=$(IFS=,; echo "${IMAGE_TAGS[*]}")
+echo "${IMAGE_TAGS_STR}"
+echo "::set-output name=tags::${IMAGE_TAGS_STR}"

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,149 @@
+name: Default (push)
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - feature/*
+    tags:
+      - v*
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  REPO: docksal/cli
+  LATEST_VERSION: 7.3
+  DOCKSAL_VERSION: develop
+
+jobs:
+  build-test-push:
+    name: Build, Test, Push
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false # Don't cancel other jobs if one fails
+      matrix:
+        version:
+          - 7.3
+          - 7.4
+
+    steps:
+      -
+        name: Install prerequisites for tests
+        run: |
+          set -xeuo pipefail
+          sudo apt-get -qq update
+          # Install cgi-fcgi binary used in tests
+          sudo apt-get -y --no-install-recommends install libfcgi-bin
+          # Install bats for tests
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+          bats -v
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Check Docker
+        run: |
+          docker version
+          docker info
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+#      -
+#        name: Build
+#        working-directory: ${{ matrix.version }}
+#        run: make buildx-with-cache
+      -
+        # Build for local use
+        name: Build and cache image (local)
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.version }}
+          file: ${{ matrix.version }}/Dockerfile
+          #platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REPO }}:build-php${{ matrix.version }} # Tag used locally in tests
+          load: true # cache image locally for use by other steps
+          #push: true # cannot use "push" together with "load"
+          cache-from: type=registry,ref=ghcr.io/${{ env.REPO }}:build-php${{ matrix.version }}
+          cache-to: type=inline # Write the cache metadata into the image configuration
+      -
+        # Print image info
+        name: Image info
+        run: |
+          set -xeuo pipefail
+          docker image ls | grep "${{ env.REPO }}"
+          docker image inspect "${{ env.REPO }}:build-php${{ matrix.version }}"
+      -
+        # Cache image layers in the registry
+        name: Build and cache (ghcr.io)
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.version }}
+          file: ${{ matrix.version }}/Dockerfile
+          #platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ env.REPO }}:build-php${{ matrix.version }} # Build cache tag in ghcr.io
+          push: ${{ github.event_name != 'pull_request' }} # Don't push for PRs
+          cache-to: type=inline # Write the cache metadata into the image configuration
+      -
+        # Run tests
+        name: Test
+        working-directory: ${{ matrix.version }}
+        env:
+          SECRET_PLATFORMSH_CLI_TOKEN: ${{ secrets.SECRET_PLATFORMSH_CLI_TOKEN }}
+          SECRET_TERMINUS_TOKEN: ${{ secrets.SECRET_TERMINUS_TOKEN }}
+        run: make test
+      -
+        # Generate image meta information
+        name: Image tags
+        id: docker_tags
+        working-directory: ${{ matrix.version }}
+        env:
+          VERSION: ${{ matrix.version }}
+        run: make tags
+#      -
+#        # Push image to registries
+#        name: Push image (Docker Hub and GitHub Container Registry)
+#        working-directory: ${{ matrix.version }}
+#        run: make release
+      -
+        # Push image to registries
+        name: Push image to registries
+        id: docker_push
+        # Don't run if the list of tags is empty
+        # Tags are only generated for develop, master and release tag builds
+        if: ${{ steps.docker_tags.outputs.tags != '' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ matrix.version }}
+          file: ${{ matrix.version }}/Dockerfile
+          #platforms: linux/amd64,linux/arm64
+          # Tag and push to Docker Hub and GitHub Container Registry
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }} # Don't push for PRs
+          cache-to: type=inline # Write the cache metadata into the image configuration

--- a/.travis-legacy.yml
+++ b/.travis-legacy.yml
@@ -28,11 +28,8 @@ install:
   - fin sysinfo
 
 script:
-  # Pull the latest edge image to speed up builds (hoping for image layer cache hits)
-  - docker pull ${REPO}:edge-php${VERSION} || true
-  # Build the base image
   - cd ${TRAVIS_BUILD_DIR}/${VERSION}
-  - travis_retry make  # Retry builds, as pecl.php.net tends to time out often
+  - travis_retry make build  # Retry builds, as pecl.php.net tends to time out often
   - make test
 
 after_success:

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -265,7 +265,7 @@ RUN set -xe; \
 	# jq
 	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
 	# yq
-	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${JQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
+	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -238,7 +238,8 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	BLACKFIRE_VERSION=1.44.1 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
 	ACQUIACLI_VERSION=2.0.9 \
-	TERMINUS_VERSION=2.4.1
+	TERMINUS_VERSION=2.4.1 \
+	JQ_VERSION=1.6
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -262,10 +263,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/typhonius/acquia_cli/releases/download/${ACQUIACLI_VERSION}/acquiacli.phar" -o /usr/local/bin/acquiacli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
+	# JQ
+	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -237,7 +237,7 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	WPCLI_VERSION=2.4.0 \
 	BLACKFIRE_VERSION=1.44.1 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
-	ACQUIACLI_VERSION=2.0.9 \
+	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
 	JQ_VERSION=1.6
 RUN set -xe; \
@@ -260,7 +260,7 @@ RUN set -xe; \
 	# Drupal Check CLI
 	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Acquia CLI
-	curl -fsSL "https://github.com/typhonius/acquia_cli/releases/download/${ACQUIACLI_VERSION}/acquiacli.phar" -o /usr/local/bin/acquiacli; \
+	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
 	# JQ
@@ -268,7 +268,7 @@ RUN set -xe; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -227,16 +227,14 @@ RUN set -xe; \
 
 # PHP tools (installed globally)
 ENV COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.17 \
-	COMPOSER2_VERSION=2.0.6 \
+	COMPOSER_VERSION=1.10.19 \
+	COMPOSER2_VERSION=2.0.8 \
 	DRUSH_VERSION=8.4.5 \
 	DRUSH_LAUNCHER_VERSION=0.8.0 \
-	# Pinned at 1.1.2 due to binaries not available for more recent releases on Github
-	DRUPAL_CHECK_VERSION=1.1.2 \
-	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.4 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.4.0 \
 	BLACKFIRE_VERSION=1.44.1 \
-	PLATFORMSH_CLI_VERSION=3.63.0 \
+	PLATFORMSH_CLI_VERSION=3.63.3 \
 	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
 	JQ_VERSION=1.6 \
@@ -316,8 +314,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.36.0 \
-	NODE_VERSION=14.15.0 \
+	NVM_VERSION=0.37.2 \
+	NODE_VERSION=14.15.1 \
 	YARN_VERSION=1.22.10
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
@@ -455,11 +453,11 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=3.6.1 \
+	CODE_SERVER_VERSION=3.7.4 \
 	VSCODE_HOME="${HOME}/code-server" \
 	VSCODE_EXT_DIRECTORY="${HOME}/code-server/extensions" \
 	VSCODE_XDEBUG_VERSION=1.13.0 \
-	VSCODE_GITLENS_VERSION=10.2.2
+	VSCODE_GITLENS_VERSION=11.0.6
 
 # Install code-server
 RUN \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -257,8 +257,6 @@ RUN set -xe; \
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
-	# Drupal Check CLI
-	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
@@ -268,7 +266,7 @@ RUN set -xe; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -239,7 +239,8 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
 	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
-	JQ_VERSION=1.6
+	JQ_VERSION=1.6 \
+	YQ_VERSION=3.4.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -261,12 +262,14 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
-	# JQ
+	# jq
 	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
+	# yq
+	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${JQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq yq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.3/Makefile
+++ b/7.3/Makefile
@@ -17,7 +17,14 @@ VOLUMES += -v /home/docker
 .PHONY: build test push shell run start stop logs clean release
 
 build:
-	docker build --cache-from=$(REPO):edge-$(SOFTWARE_VERSION) -t $(REPO):$(BUILD_TAG) .
+	docker build -t $(REPO):$(BUILD_TAG) .
+
+# See https://docs.docker.com/buildx/working-with-buildx/
+# See https://github.com/docker/buildx
+buildx:
+	docker buildx build --tag $(REPO):$(BUILD_TAG) .
+buildx-with-cache:
+	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(REPO):$(BUILD_TAG) --cache-to=type=inline --tag=$(REPO):$(BUILD_TAG) .
 
 test:
 	IMAGE=$(REPO):$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
@@ -53,6 +60,9 @@ logs-follow:
 
 clean:
 	docker rm -vf $(NAME) >/dev/null 2>&1 || true
+
+tags:
+	@../.github/scripts/docker-tags.sh
 
 release:
 	@../scripts/docker-push.sh

--- a/7.3/startup.sh
+++ b/7.3/startup.sh
@@ -130,6 +130,22 @@ terminus_login ()
 	fi
 }
 
+# Acquia CLI login
+acli_login ()
+{
+	echo-debug "Authenticating with Acquia..."
+	# This has to be done using the docker user via su to load the user environment
+	# Note: Using 'su -l' to initiate a login session and have .profile sourced for the docker user
+	local command="acli auth:login --key='${ACQUIA_CLI_KEY}' --secret='${ACQUIA_CLI_SECRET}' --no-interaction"
+	local output=$(su -l docker -c "${command}" 2>&1)
+	if [[ $? != 0 ]]; then
+		echo-debug "ERROR: Acquia authentication failed."
+		echo
+		echo "$output"
+		echo
+	fi
+}
+
 # Git settings
 git_settings ()
 {
@@ -177,6 +193,9 @@ chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 # otherwise the docker user may not have write access to /home/docker, where the auth session data is stored.
 # Automatically authenticate with Pantheon if Terminus token is present
 [[ "$TERMINUS_TOKEN" != "" ]] && terminus_login
+
+# Authenticate to Acquia CLI
+[[ "$ACQUIA_CLI_KEY" != "" ]] && [[ "$ACQUIA_CLI_SECRET" != "" ]] && acli_login
 
 # If crontab file is found within project add contents to user crontab file.
 if [[ -f ${PROJECT_ROOT}/.docksal/services/cli/crontab ]]; then

--- a/7.3/startup.sh
+++ b/7.3/startup.sh
@@ -87,7 +87,8 @@ render_tmpl ()
 
 	if [[ -f "${tmpl}" ]]; then
 		echo-debug "Rendering template: ${tmpl}..."
-		gomplate --file "${tmpl}" --out "${file}"
+		# gomplate started throwing an empty line into stderr in v3.7.0, so we have to mute it below
+		gomplate --file "${tmpl}" --out "${file}" &>/dev/null
 	else
 		echo-debug "Error: Template file not found: ${tmpl}"
 		return 1

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -265,7 +265,7 @@ RUN set -xe; \
 	# jq
 	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
 	# yq
-	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${JQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
+	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -227,16 +227,14 @@ RUN set -xe; \
 
 # PHP tools (installed globally)
 ENV COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.17 \
-	COMPOSER2_VERSION=2.0.6 \
+	COMPOSER_VERSION=1.10.19 \
+	COMPOSER2_VERSION=2.0.8 \
 	DRUSH_VERSION=8.4.5 \
 	DRUSH_LAUNCHER_VERSION=0.8.0 \
-	# Pinned at 1.1.2 due to binaries not available for more recent releases on Github
-	DRUPAL_CHECK_VERSION=1.1.2 \
-	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.4 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.4.0 \
 	BLACKFIRE_VERSION=1.44.1 \
-	PLATFORMSH_CLI_VERSION=3.63.0 \
+	PLATFORMSH_CLI_VERSION=3.63.3 \
 	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
 	JQ_VERSION=1.6 \
@@ -316,8 +314,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.36.0 \
-	NODE_VERSION=14.15.0 \
+	NVM_VERSION=0.37.2 \
+	NODE_VERSION=14.15.1 \
 	YARN_VERSION=1.22.10
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
@@ -456,11 +454,11 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=3.6.1 \
+	CODE_SERVER_VERSION=3.7.4 \
 	VSCODE_HOME="${HOME}/code-server" \
 	VSCODE_EXT_DIRECTORY="${HOME}/code-server/extensions" \
 	VSCODE_XDEBUG_VERSION=1.13.0 \
-	VSCODE_GITLENS_VERSION=10.2.2
+	VSCODE_GITLENS_VERSION=11.0.6
 
 # Install code-server
 RUN \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -238,7 +238,8 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	BLACKFIRE_VERSION=1.44.1 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
 	ACQUIACLI_VERSION=2.0.9 \
-	TERMINUS_VERSION=2.4.1
+	TERMINUS_VERSION=2.4.1 \
+	JQ_VERSION=1.6
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -262,10 +263,12 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/typhonius/acquia_cli/releases/download/${ACQUIACLI_VERSION}/acquiacli.phar" -o /usr/local/bin/acquiacli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
+	# JQ
+	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -237,7 +237,7 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	WPCLI_VERSION=2.4.0 \
 	BLACKFIRE_VERSION=1.44.1 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
-	ACQUIACLI_VERSION=2.0.9 \
+	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
 	JQ_VERSION=1.6
 RUN set -xe; \
@@ -260,7 +260,7 @@ RUN set -xe; \
 	# Drupal Check CLI
 	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Acquia CLI
-	curl -fsSL "https://github.com/typhonius/acquia_cli/releases/download/${ACQUIACLI_VERSION}/acquiacli.phar" -o /usr/local/bin/acquiacli; \
+	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
 	# JQ
@@ -268,7 +268,7 @@ RUN set -xe; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acquiacli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -257,8 +257,6 @@ RUN set -xe; \
 	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_static_amd64" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
-	# Drupal Check CLI
-	curl -fsSL "https://github.com/mglaman/drupal-check/releases/download/${DRUPAL_CHECK_VERSION}/drupal-check.phar" -o /usr/local/bin/drupal-check; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
@@ -268,7 +266,7 @@ RUN set -xe; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drupal-check drush8 drush drupal wp blackfire platform acli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -239,7 +239,8 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	PLATFORMSH_CLI_VERSION=3.63.0 \
 	ACQUIA_CLI_VERSION=1.3.0 \
 	TERMINUS_VERSION=2.4.1 \
-	JQ_VERSION=1.6
+	JQ_VERSION=1.6 \
+	YQ_VERSION=3.4.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -261,12 +262,14 @@ RUN set -xe; \
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus
 	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
-	# JQ
+	# jq
 	curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
+	# yq
+	curl -fsSL "https://github.com/mikefarah/yq/releases/download/${JQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq; \
 	# Set Default Composer Version
 	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
 	# Make all downloaded binaries executable in one shot
-	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq);
+	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus jq yq);
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/7.4/Makefile
+++ b/7.4/Makefile
@@ -17,7 +17,14 @@ VOLUMES += -v /home/docker
 .PHONY: build test push shell run start stop logs clean release
 
 build:
-	docker build --cache-from=$(REPO):edge-$(SOFTWARE_VERSION) -t $(REPO):$(BUILD_TAG) .
+	docker build -t $(REPO):$(BUILD_TAG) .
+
+# See https://docs.docker.com/buildx/working-with-buildx/
+# See https://github.com/docker/buildx
+buildx:
+	docker buildx build --tag $(REPO):$(BUILD_TAG) .
+buildx-with-cache:
+	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(REPO):$(BUILD_TAG) --cache-to=type=inline --tag=$(REPO):$(BUILD_TAG) .
 
 test:
 	IMAGE=$(REPO):$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
@@ -53,6 +60,9 @@ logs-follow:
 
 clean:
 	docker rm -vf $(NAME) >/dev/null 2>&1 || true
+
+tags:
+	@../.github/scripts/docker-tags.sh
 
 release:
 	@../scripts/docker-push.sh

--- a/7.4/startup.sh
+++ b/7.4/startup.sh
@@ -93,7 +93,8 @@ render_tmpl ()
 
 	if [[ -f "${tmpl}" ]]; then
 		echo-debug "Rendering template: ${tmpl}..."
-		gomplate --file "${tmpl}" --out "${file}"
+		# gomplate started throwing an empty line into stderr in v3.7.0, so we have to mute it below
+		gomplate --file "${tmpl}" --out "${file}" &>/dev/null
 	else
 		echo-debug "Error: Template file not found: ${tmpl}"
 		return 1

--- a/7.4/startup.sh
+++ b/7.4/startup.sh
@@ -136,6 +136,22 @@ terminus_login ()
 	fi
 }
 
+# Acquia CLI login
+acli_login ()
+{
+	echo-debug "Authenticating with Acquia..."
+	# This has to be done using the docker user via su to load the user environment
+	# Note: Using 'su -l' to initiate a login session and have .profile sourced for the docker user
+	local command="acli auth:login --key='${ACQUIA_CLI_KEY}' --secret='${ACQUIA_CLI_SECRET}' --no-interaction"
+	local output=$(su -l docker -c "${command}" 2>&1)
+	if [[ $? != 0 ]]; then
+		echo-debug "ERROR: Acquia authentication failed."
+		echo
+		echo "$output"
+		echo
+	fi
+}
+
 # Git settings
 git_settings ()
 {
@@ -186,6 +202,9 @@ chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
 # otherwise the docker user may not have write access to /home/docker, where the auth session data is stored.
 # Automatically authenticate with Pantheon if Terminus token is present
 [[ "$TERMINUS_TOKEN" != "" ]] && terminus_login
+
+# Authenticate to Acquia CLI
+[[ "$ACQUIA_CLI_KEY" != "" ]] && [[ "$ACQUIA_CLI_SECRET" != "" ]] && acli_login
 
 # If crontab file is found within project add contents to user crontab file.
 if [[ -f ${PROJECT_ROOT}/.docksal/services/cli/crontab ]]; then

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Example:
 services:
   cli:
     environment:
-      COMPOSER_DEFAULT_VERSION=1
+      - COMPOSER_DEFAULT_VERSION=1
 ```
 
 The following Composer optimization packages are no longer relevant/compatible with Composer v2 and have been dropped:

--- a/README.md
+++ b/README.md
@@ -236,4 +236,4 @@ The following Composer optimization packages are no longer relevant/compatible w
 - [zaporylie/composer-drupal-optimizations](https://github.com/zaporylie/composer-drupal-optimizations) 
 
 To benefit from these optimizations with Composer v1, you would need to pin the image to an older version.  
-See Docksal [documentation](https://docs.docksal.io/service/cli/settings#php-versions) for more details.
+See Docksal [documentation](https://docs.docksal.io/service/cli/settings#composer) for more details.

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This image(s) is part of the [Docksal](https://docksal.io) image library.
 - xdebug
 - composer v1 & v2
 - drush (Drupal)
-  - drush launcher with a fallback to a global drush 8 
+  - drush launcher with a fallback to a global drush 8
   - registry_rebuild module
   - coder-8.x + phpcs
 - drupal console launcher (Drupal)
 - wp-cli (Wordpress)
 - mg2-codegen (Magento 2)
 
-This image uses the official `php-fpm` images from [Docker Hub](https://hub.docker.com/_/php/) as the base.  
+This image uses the official `php-fpm` images from [Docker Hub](https://hub.docker.com/_/php/) as the base.
 This means that PHP and all modules are installed from source. Extra modules have to be installed in the same
 manner (installing them with `apt-get` won't work).
 
@@ -77,17 +77,17 @@ cli
 
 NodeJS is installed via `nvm` in the `docker` user's profile inside the image (`/home/docker/.nvm`).
 
-If you need a different version of node, use `nvm` to install it, e.g, `nvm install 11.6.0`. 
-Then, use `nvm use 11.6.0` to use it in the current session or `nvm alias default 11.6.0` to use it by default. 
+If you need a different version of node, use `nvm` to install it, e.g, `nvm install 11.6.0`.
+Then, use `nvm use 11.6.0` to use it in the current session or `nvm alias default 11.6.0` to use it by default.
 
 ## Python
 
-- pyenv 
+- pyenv
 - python 3.8.3
 
 This image comes with a system level installed Python version from upstream (Debian 9).
 
-Additional versions can be installed via `pyenv`, e.g. `pyenv install 3.7.0`. 
+Additional versions can be installed via `pyenv`, e.g. `pyenv install 3.7.0`.
 Then, use `pyenv local 3.7.0` to use it in the current session or `pyenv global 3.7.0` to set is as the default.
 
 Note: additional versions will be installed in the `docker` user's profile inside the image (`/home/docker/.pyenv`).
@@ -101,8 +101,8 @@ Note: additional versions will be installed in the `docker` user's profile insid
 
 Ruby is installed via `rvm` in the `docker` user's profile inside the image (`/home/docker/.rvm`).
 
-If you need a different version, use `rvm` to install it, e.g, `rvm install 2.5.1`. 
-Then, `rvm use 2.5.1` to use it in the current session or `rvm --default use 2.5.1` to use it by default. 
+If you need a different version, use `rvm` to install it, e.g, `rvm install 2.5.1`.
+Then, `rvm use 2.5.1` to use it in the current session or `rvm --default use 2.5.1` to use it by default.
 
 ## Notable console tools
 
@@ -117,7 +117,7 @@ Then, `rvm use 2.5.1` to use it in the current session or `rvm --default use 2.5
 
 ## Hosting provider tools
 
-- `acquia_cli` for Acquia Cloud APIv2 ([Acquia](https://www.acquia.com/)) 
+- `acquiacli` for Acquia Cloud APIv2 ([Acquia](https://www.acquia.com/))
 - `terminus` ([Pantheon](https://pantheon.io/))
 - `platform` ([Platform.sh](https://platform.sh/))
 
@@ -140,20 +140,20 @@ follow the [standard crontab format](http://www.nncron.ru/help/EN/working/cron-f
 <a name="secrets"></a>
 ## Secrets and integrations
 
-`cli` can read secrets from environment variables and configure the respective integrations automatically at start.  
+`cli` can read secrets from environment variables and configure the respective integrations automatically at start.
 
-The recommended place store secrets in Docksal is the global `$HOME/.docksal/docksal.env` file on the host. From there, 
+The recommended place store secrets in Docksal is the global `$HOME/.docksal/docksal.env` file on the host. From there,
 secrets are injected into the `cli` container's environment.
 
 Below is the list of secrets currently supported.
 
 `SECRET_SSH_PRIVATE_KEY`
 
-Use to pass a private SSH key. The key will be stored in `/home/docker/.ssh/id_rsa` inside `cli` and will be considered 
-by the SSH client **in addition** to the keys loaded in `docksal-ssh-agent` when establishing a SSH connection 
+Use to pass a private SSH key. The key will be stored in `/home/docker/.ssh/id_rsa` inside `cli` and will be considered
+by the SSH client **in addition** to the keys loaded in `docksal-ssh-agent` when establishing a SSH connection
 from within `cli`.
 
-This is useful when you need a project stack to inherit a private SSH key that is not shared with other project stacks 
+This is useful when you need a project stack to inherit a private SSH key that is not shared with other project stacks
 on the same host (e.g. in shared CI environments).
 
 The value must be base64 encoded, i.e:
@@ -162,26 +162,26 @@ The value must be base64 encoded, i.e:
 cat /path/to/some_key_rsa | base64
 ```
 
-`SECRET_ACQUIACLI_KEY` and `SECRET_ACQUIACLI_SECRET`
+`SECRET_ACQUIA_CLI_KEY` and `SECRET_ACQUIA_CLI_SECRET`
 
-Credentials used to authenticate [Acquia CLI](https://github.com/typhonius/acquia_cli) with Acquia Cloud APIv2.
-Stored as `ACQUIACLI_KEY` and `ACQUIACLI_SECRET` environment variables inside `cli`.
+Credentials used to authenticate [Acquia CLI](https://github.com/acquia/cli) with Acquia Cloud APIv2.
+Stored as `ACQUIA_CLI_KEY` and `ACQUIA_CLI_SECRET` environment variables inside `cli`.
 
-Acquia CLI is installed and available globally in `cli`.
+Acquia CLI is installed and available globally in `cli` as `acli`.
 
 `SECRET_TERMINUS_TOKEN`
 
 Credentials used to authenticate [Terminus](https://pantheon.io/docs/terminus) with Pantheon.
 Stored in `/home/docker/.terminus/` inside `cli`.
 
-Terminus is installed and available globally in `cli`.
+Terminus is installed and available globally in `cli` as `terminus`.
 
 `SECRET_PLATFORMSH_CLI_TOKEN`
 
 Credentials used to authenticate with the [Platform.sh CLI](https://github.com/platformsh/platformsh-cli) tool.
 Stored in `/home/docker/.platform` inside `cli`.
 
-Platform CLI is installed and available globally in `cli`.
+Platform CLI is installed and available globally in `cli` as `platform`.
 
 `WEB_KEEPALIVE`
 
@@ -195,7 +195,7 @@ These can be passed as environment variables and will be applied at the containe
 ```
 GIT_USER_EMAIL="git@example.com"
 GIT_USER_NAME="Docksal CLI"
-``` 
+```
 
 
 <a name="ide"></a>
@@ -218,7 +218,7 @@ Store your preferred password in this variable if you need to password protect t
 
 ## Composer
 
-Composer v1 and v2 are both installed in the container. v2 is set as the default version, but while not all 
+Composer v1 and v2 are both installed in the container. v2 is set as the default version, but while not all
 projects may be able to work with v2 quite yet, v1 is available by setting the `COMPOSER_DEFAULT_VERSION` variable to `1`.
 
 Example:
@@ -233,7 +233,7 @@ services:
 The following Composer optimization packages are no longer relevant/compatible with Composer v2 and have been dropped:
 
 - [hirak/prestissimo](https://github.com/hirak/prestissimo)
-- [zaporylie/composer-drupal-optimizations](https://github.com/zaporylie/composer-drupal-optimizations) 
+- [zaporylie/composer-drupal-optimizations](https://github.com/zaporylie/composer-drupal-optimizations)
 
-To benefit from these optimizations with Composer v1, you would need to pin the image to an older version.  
+To benefit from these optimizations with Composer v1, you would need to pin the image to an older version.
 See Docksal [documentation](https://docs.docksal.io/service/cli/settings#composer) for more details.

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Store your preferred password in this variable if you need to password protect t
 
 ## Composer
 
-Versions 1 and 2 are both installed in the container. Version 2 is set as the default version, but while not all 
-projects may be able to work with version 2 quite yet, version 1 is available by setting the `COMPOSER_DEFAULT_VERSION` variable to `1`.
+Composer v1 and v2 are both installed in the container. v2 is set as the default version, but while not all 
+projects may be able to work with v2 quite yet, v1 is available by setting the `COMPOSER_DEFAULT_VERSION` variable to `1`.
 
 Example:
 
@@ -229,3 +229,11 @@ services:
     environment:
       COMPOSER_DEFAULT_VERSION=1
 ```
+
+The following Composer optimization packages are no longer relevant/compatible with Composer v2 and have been dropped:
+
+- [hirak/prestissimo](https://github.com/hirak/prestissimo)
+- [zaporylie/composer-drupal-optimizations](https://github.com/zaporylie/composer-drupal-optimizations) 
+
+To benefit from these optimizations with Composer v1, you would need to pin the image to an older version.  
+See Docksal [documentation](https://docs.docksal.io/service/cli/settings#php-versions) for more details.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -83,6 +83,7 @@ _healthcheck_wait ()
 		git-lfs \
 		gcc \
 		html2text \
+		jq \
 		less \
 		make \
 		mc \
@@ -97,6 +98,7 @@ _healthcheck_wait ()
 		sudo \
 		unzip \
 		wget \
+		yq \
 		zip \
 	'
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -275,6 +275,11 @@ _healthcheck_wait ()
 	[[ ${status} == 0 ]]
 	unset output
 
+	# Check Acquia CLI version
+	run docker exec -u docker "$NAME" bash -lc 'set -x; acli --version | grep "^Acquia CLI ${ACQUIA_CLI_VERSION}$"'
+	[[ ${status} == 0 ]]
+	unset output
+
 	### Cleanup ###
 	make clean
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -228,32 +228,32 @@ _healthcheck_wait ()
 	### Tests ###
 
 	# Check Composer v1 version (legacy)
-	run docker exec -u docker "$NAME" bash -lc 'composer1 --version | grep "^Composer version ${COMPOSER_VERSION} "'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; composer1 --version | grep "^Composer version ${COMPOSER_VERSION} "'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Composer v2 version (default)
-	run docker exec -u docker "$NAME" bash -lc 'composer --version | grep "^Composer version ${COMPOSER2_VERSION} "'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; composer --version | grep "^Composer version ${COMPOSER2_VERSION} "'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Drush Launcher version
-	run docker exec -u docker "$NAME" bash -lc 'drush --version | grep "^Drush Launcher Version: ${DRUSH_LAUNCHER_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; drush --version | grep "^Drush Launcher Version: ${DRUSH_LAUNCHER_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Drush version
-	run docker exec -u docker "$NAME" bash -lc 'drush --version | grep "^ Drush Version   :  ${DRUSH_VERSION} $"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; drush --version | grep "^ Drush Version   :  ${DRUSH_VERSION} $"'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Drupal Console version
-	run docker exec -u docker "$NAME" bash -lc 'drupal --version | grep "^Drupal Console Launcher ${DRUPAL_CONSOLE_LAUNCHER_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; drupal --version | grep "^Drupal Console Launcher ${DRUPAL_CONSOLE_LAUNCHER_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Wordpress CLI version
-	run docker exec -u docker "$NAME" bash -lc 'wp --version | grep "^WP-CLI ${WPCLI_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; wp --version | grep "^WP-CLI ${WPCLI_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 
@@ -261,17 +261,17 @@ _healthcheck_wait ()
 	# TODO: this needs to be replaced with the actual version check
 	# See https://github.com/staempfli/magento2-code-generator/issues/15
 	#run docker exec -u docker "$NAME" bash -lc 'mg2-codegen --version | grep "^mg2-codegen ${MG_CODEGEN_VERSION}$"'
-	run docker exec -u docker "$NAME" bash -lc 'mg2-codegen --version | grep "^mg2-codegen @git-version@$"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; mg2-codegen --version | grep "^mg2-codegen @git-version@$"'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Terminus version
-	run docker exec -u docker "$NAME" bash -lc 'terminus --version | grep "^Terminus ${TERMINUS_VERSION}$"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; terminus --version | grep "^Terminus ${TERMINUS_VERSION}$"'
 	[[ ${status} == 0 ]]
 	unset output
 
 	# Check Platform CLI version
-	run docker exec -u docker "$NAME" bash -lc 'platform --version | grep "Platform.sh CLI ${PLATFORMSH_CLI_VERSION}"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; platform --version | grep "Platform.sh CLI ${PLATFORMSH_CLI_VERSION}"'
 	[[ ${status} == 0 ]]
 	unset output
 


### PR DESCRIPTION
- Build and CI overhaul
  - Switched to GitHub Actions for CI
  - Switched to Docker BuilKit for image builds
  - Pushing images to Docker Hub as well as GitHub Container Registry
- Updates to console tools
  - Switch to official acquia/cli + automated login
    - Switched from typhonius/acquia_cli to the official acquia/cli (`acli` binary)
    - Config variables changed to `SECRET_ACQUIA_CLI_KEY` and `SECRET_ACQUIA_CLI_SECRET`
  - Added `jq` and `yq`
  - Dropped `drupal-check`
  - composer 1.10.19 + 2.0.8
  - drupal console launcher 1.9.7
  - platform.sh cli 3.63.3
  - nvm 0.36.0, nodejs 14.15.1
  - code-server 3.7.4, gitlens 11.0.6
- Fixed `COMPOSER_DEFAULT_VERSION` example in README
- Fixed issue with `gomplate` printing an empty line in `startup.sh`
