### PR TITLE
Align image tags with other Docksal images

### DIFF
--- a/.github/scripts/docker-tags.sh
+++ b/.github/scripts/docker-tags.sh
@@ -2,43 +2,49 @@
 
 # Generates docker images tags for the docker/build-push-action@v2 action depending on the branch/tag.
 
-declare -a IMAGE_TAGS
+declare -a registryArr
+registryArr+=("docker.io") # Docker Hub
+registryArr+=("ghcr.io") # GitHub Container Registry
+
+declare -a imageTagArr
 
 # feature/* => sha-xxxxxxx
 # Note: disabled
 #if [[ "${GITHUB_REF}" =~ "refs/heads/feature/" ]]; then
 #	GIT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7) # Short SHA (7 characters)
-#	IMAGE_TAGS+=("${REPO}:sha-${GIT_SHA7}-php${VERSION}")
-#	IMAGE_TAGS+=("ghcr.io/${REPO}:sha-${GIT_SHA7}-php${VERSION}")
+#	imageTagArr+=("${IMAGE}:php${VERSION}-sha-${GIT_SHA7}")
 #fi
 
-# develop => edge
+# develop => version-edge
 if [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
-	IMAGE_TAGS+=("${REPO}:edge-php${VERSION}")
-	IMAGE_TAGS+=("ghcr.io/${REPO}:edge-php${VERSION}")
+	imageTagArr+=("${IMAGE}:php${VERSION}-edge")
 fi
 
-# master => stable
+# master => version
 if [[ "${GITHUB_REF}" == "refs/heads/master" ]]; then
-	IMAGE_TAGS+=("${REPO}:stable-php${VERSION}")
-	IMAGE_TAGS+=("ghcr.io/${REPO}:stable-php${VERSION}")
+	imageTagArr+=("${IMAGE}:php${VERSION}")
 fi
 
 # tags/v1.0.0 => 1.0
 if [[ "${GITHUB_REF}" =~ "refs/tags/" ]]; then
 	# Extract version parts from release tag
-	IFS='.' read -a ver_arr <<< "${GITHUB_REF#refs/tags/}"
-	VERSION_MAJOR=${ver_arr[0]#v*}  # 2.7.0 => "2"
-	VERSION_MINOR=${ver_arr[1]}  # "2.7.0" => "7"
-	IMAGE_TAGS+=("${REPO}:stable-php${VERSION}")
-	IMAGE_TAGS+=("${REPO}:${VERSION_MAJOR}-php${VERSION}")
-	IMAGE_TAGS+=("${REPO}:${VERSION_MAJOR}.${VERSION_MINOR}-php${VERSION}")
-	IMAGE_TAGS+=("ghcr.io/${REPO}:stable-php${VERSION}")
-	IMAGE_TAGS+=("ghcr.io/${REPO}:${VERSION_MAJOR}-php${VERSION}")
-	IMAGE_TAGS+=("ghcr.io/${REPO}:${VERSION_MAJOR}.${VERSION_MINOR}-php${VERSION}")
+	IFS='.' read -a release_arr <<< "${GITHUB_REF#refs/tags/}"
+	releaseMajor=${release_arr[0]#v*}  # 2.7.0 => "2"
+	releaseMinor=${release_arr[1]}  # "2.7.0" => "7"
+	imageTagArr+=("${IMAGE}:php${VERSION}")
+	imageTagArr+=("${IMAGE}:php${VERSION}-${releaseMajor}")
+	imageTagArr+=("${IMAGE}:php${VERSION}-${releaseMajor}.${releaseMinor}")
 fi
 
-# Output a comma concatenated list of image tags
-IMAGE_TAGS_STR=$(IFS=,; echo "${IMAGE_TAGS[*]}")
-echo "${IMAGE_TAGS_STR}"
-echo "::set-output name=tags::${IMAGE_TAGS_STR}"
+# Build an array of registry/image:tag values
+declare -a repoImageTagArr
+for registry in ${registryArr[@]}; do
+	for imageTag in ${imageTagArr[@]}; do
+		repoImageTagArr+=("${registry}/${imageTag}")
+	done
+done
+
+# Print with new lines for output in build logs
+(IFS=$'\n'; echo "${repoImageTagArr[*]}")
+# Using newlines in outputs variables does not seem to work, so we'll use comas
+(IFS=$','; echo "::set-output name=tags::${repoImageTagArr[*]}")

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -14,7 +14,7 @@ defaults:
     shell: bash
 
 env:
-  REPO: docksal/cli
+  IMAGE: docksal/cli
   LATEST_VERSION: 7.3
   DOCKSAL_VERSION: develop
 
@@ -83,18 +83,18 @@ jobs:
           context: ${{ matrix.version }}
           file: ${{ matrix.version }}/Dockerfile
           #platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REPO }}:build-php${{ matrix.version }} # Tag used locally in tests
+          tags: ${{ env.IMAGE }}:php${{ matrix.version }}-build # Tag used locally in tests
           load: true # cache image locally for use by other steps
           #push: true # cannot use "push" together with "load"
-          cache-from: type=registry,ref=ghcr.io/${{ env.REPO }}:build-php${{ matrix.version }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.IMAGE }}:php${{ matrix.version }}-build
           cache-to: type=inline # Write the cache metadata into the image configuration
       -
         # Print image info
         name: Image info
         run: |
           set -xeuo pipefail
-          docker image ls | grep "${{ env.REPO }}"
-          docker image inspect "${{ env.REPO }}:build-php${{ matrix.version }}"
+          docker image ls | grep "${{ env.IMAGE }}"
+          docker image inspect "${{ env.IMAGE }}:php${{ matrix.version }}-build"
       -
         # Cache image layers in the registry
         name: Build and cache (ghcr.io)
@@ -103,7 +103,7 @@ jobs:
           context: ${{ matrix.version }}
           file: ${{ matrix.version }}/Dockerfile
           #platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ env.REPO }}:build-php${{ matrix.version }} # Build cache tag in ghcr.io
+          tags: ghcr.io/${{ env.IMAGE }}:php${{ matrix.version }}-build # Build cache tag in ghcr.io
           push: ${{ github.event_name != 'pull_request' }} # Don't push for PRs
           cache-to: type=inline # Write the cache metadata into the image configuration
       -

--- a/7.3/Makefile
+++ b/7.3/Makefile
@@ -4,8 +4,8 @@
 VERSION ?= 7.3
 
 SOFTWARE_VERSION ?= php$(VERSION)
-BUILD_TAG = build-$(SOFTWARE_VERSION)
-REPO = docksal/cli
+BUILD_TAG = $(SOFTWARE_VERSION)-build
+IMAGE = docksal/cli
 NAME = docksal-cli-$(VERSION)
 CWD = $(shell pwd)
 
@@ -17,26 +17,26 @@ VOLUMES += -v /home/docker
 .PHONY: build test push shell run start stop logs clean release
 
 build:
-	docker build -t $(REPO):$(BUILD_TAG) .
+	docker build -t $(IMAGE):$(BUILD_TAG) .
 
 # See https://docs.docker.com/buildx/working-with-buildx/
 # See https://github.com/docker/buildx
 buildx:
-	docker buildx build --tag $(REPO):$(BUILD_TAG) .
+	docker buildx build --tag $(IMAGE):$(BUILD_TAG) .
 buildx-with-cache:
-	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(REPO):$(BUILD_TAG) --cache-to=type=inline --tag=$(REPO):$(BUILD_TAG) .
+	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(IMAGE):$(BUILD_TAG) --cache-to=type=inline --tag=$(IMAGE):$(BUILD_TAG) .
 
 test:
-	IMAGE=$(REPO):$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
+	IMAGE=$(IMAGE) BUILD_TAG=$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
 
 push:
-	docker push $(REPO):$(BUILD_TAG)
+	docker push $(IMAGE):$(BUILD_TAG)
 
 run: clean
-	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(BUILD_TAG)
+	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(BUILD_TAG)
 
 start: clean
-	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(BUILD_TAG)
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(BUILD_TAG)
 
 # Non-interactive and non-tty docker exec (uses LF instead of CRLF line endings)
 exec:

--- a/7.4/Makefile
+++ b/7.4/Makefile
@@ -4,8 +4,8 @@
 VERSION ?= 7.4
 
 SOFTWARE_VERSION ?= php$(VERSION)
-BUILD_TAG = build-$(SOFTWARE_VERSION)
-REPO = docksal/cli
+BUILD_TAG = $(SOFTWARE_VERSION)-build
+IMAGE = docksal/cli
 NAME = docksal-cli-$(VERSION)
 CWD = $(shell pwd)
 
@@ -17,26 +17,26 @@ VOLUMES += -v /home/docker
 .PHONY: build test push shell run start stop logs clean release
 
 build:
-	docker build -t $(REPO):$(BUILD_TAG) .
+	docker build -t $(IMAGE):$(BUILD_TAG) .
 
 # See https://docs.docker.com/buildx/working-with-buildx/
 # See https://github.com/docker/buildx
 buildx:
-	docker buildx build --tag $(REPO):$(BUILD_TAG) .
+	docker buildx build --tag $(IMAGE):$(BUILD_TAG) .
 buildx-with-cache:
-	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(REPO):$(BUILD_TAG) --cache-to=type=inline --tag=$(REPO):$(BUILD_TAG) .
+	docker buildx build --cache-from=type=registry,ref=ghcr.io/$(IMAGE):$(BUILD_TAG) --cache-to=type=inline --tag=$(IMAGE):$(BUILD_TAG) .
 
 test:
-	IMAGE=$(REPO):$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
+	IMAGE=$(IMAGE) BUILD_TAG=$(BUILD_TAG) NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
 
 push:
-	docker push $(REPO):$(BUILD_TAG)
+	docker push $(IMAGE):$(BUILD_TAG)
 
 run: clean
-	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(BUILD_TAG)
+	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(BUILD_TAG)
 
 start: clean
-	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(BUILD_TAG)
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(BUILD_TAG)
 
 # Non-interactive and non-tty docker exec (uses LF instead of CRLF line endings)
 exec:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ This image(s) is part of the [Docksal](https://docksal.io) image library.
 ## Versions and image tag naming convention
 
 - Stable versions
-  - `2.11-php7.3`, `php7.3`, `latest` - PHP 7.3
-  - `2.11-php7.4`, `php7.4` - PHP 7.4
+  - `php7.3-2.14`, `php7.3-2`, `php7.3` - PHP 7.3
+  - `php7.4-2.14`, `php7.4-2`, `php7.4`, `latest` - PHP 7.4
 - Development versions
-  - `edge-php7.3` - PHP 7.3
-  - `edge-php7.4` - PHP 7.4
+  - `php7.3-edge` - PHP 7.3
+  - `php7.4-edge` - PHP 7.4
 
 
 ## PHP

--- a/code-server/Makefile
+++ b/code-server/Makefile
@@ -2,8 +2,8 @@
 -include env_make
 
 VERSION ?= 7.3
-REPO = docksal/cli
-FROM_TAG = build-$(VERSION)
+IMAGE = docksal/cli
+FROM_TAG = $(VERSION)-build
 TAG = $(FROM_TAG)-ide
 NAME = docksal-cli-$(VERSION)-ide
 CWD = $(shell pwd)
@@ -14,19 +14,19 @@ VOLUMES += -v /home/docker
 .PHONY: build test push shell run start stop logs clean release
 
 build:
-	docker build --build-arg FROM_TAG=$(FROM_TAG) -t $(REPO):$(TAG) .
+	docker build --build-arg FROM_TAG=$(FROM_TAG) -t $(IMAGE):$(TAG) .
 
 test:
-	IMAGE=$(REPO):$(TAG) NAME=$(NAME) tests/test.bats
+	IMAGE=$(IMAGE):$(TAG) NAME=$(NAME) tests/test.bats
 
 push:
-	docker push $(REPO):$(TAG)
+	docker push $(IMAGE):$(TAG)
 
 run: clean
-	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG)
+	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(TAG)
 
 start: clean
-	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(REPO):$(TAG)
+	docker run -d --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(IMAGE):$(TAG)
 
 # Non-interactive and non-tty docker exec (uses LF instead of CRLF line endings)
 exec:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -119,7 +119,7 @@ _healthcheck_wait ()
 	docker run --name "$NAME" -d \
 		-v /home/docker \
 		-v $(pwd)/../tests/docroot:/var/www/docroot \
-		"$IMAGE"
+		${IMAGE}:${BUILD_TAG}
 	docker cp $(pwd)/../tests/scripts "$NAME:/var/www/"
 
 	run _healthcheck_wait


### PR DESCRIPTION
All newer Docksal images follow this naming convention for tags:

```
<image-repo>:<software-version>[-<image-stability-tag>][-<flavor>]
```

Older images (including docksal/cli today) used this:

```
<image-repo>:[<image-stability-tag>]-<software-version>
```
