### PR TITLE
Revert XDebug Port

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -426,7 +426,7 @@ ENV \
 	XHPROF_OUTPUT_DIR=/tmp/xhprof
 
 # TODO: [v3] remove and set these via docker-compose
-EXPOSE 9003
+EXPOSE 9000
 EXPOSE 22
 EXPOSE 3000
 

--- a/7.3/config/php/xdebug.ini
+++ b/7.3/config/php/xdebug.ini
@@ -6,3 +6,4 @@ xdebug.mode=debug
 ; xdebug.xdebug.remote_port is set at runtime: 9003 (default)
 xdebug.idekey=xdebug_session
 xdebug.max_nesting_level=256
+xdebug.port=9000

--- a/7.3/config/php/xdebug.ini
+++ b/7.3/config/php/xdebug.ini
@@ -6,4 +6,4 @@ xdebug.mode=debug
 ; xdebug.xdebug.remote_port is set at runtime: 9003 (default)
 xdebug.idekey=xdebug_session
 xdebug.max_nesting_level=256
-xdebug.port=9000
+xdebug.client_port=9000

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -427,7 +427,7 @@ ENV \
 	XHPROF_OUTPUT_DIR=/tmp/xhprof
 
 # TODO: [v3] remove and set these via docker-compose
-EXPOSE 9003
+EXPOSE 9000
 EXPOSE 22
 EXPOSE 3000
 

--- a/7.4/config/php/xdebug.ini
+++ b/7.4/config/php/xdebug.ini
@@ -6,3 +6,4 @@ xdebug.mode=debug
 ; xdebug.xdebug.remote_port is set at runtime: 9003 (default)
 xdebug.idekey=xdebug_session
 xdebug.max_nesting_level=256
+xdebug.port=9000

--- a/7.4/config/php/xdebug.ini
+++ b/7.4/config/php/xdebug.ini
@@ -6,4 +6,4 @@ xdebug.mode=debug
 ; xdebug.xdebug.remote_port is set at runtime: 9003 (default)
 xdebug.idekey=xdebug_session
 xdebug.max_nesting_level=256
-xdebug.port=9000
+xdebug.client_port=9000


### PR DESCRIPTION
* Reverted xdebug port to use 9000 instead of the new 9003 to not introduce breaking change.