### PR TITLE
Project level Composer vendor/bin in PATH

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -324,7 +324,9 @@ RUN set -e; \
 	# Set drush8 as a global fallback for Drush Launcher
 	echo -e "\n""export DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8" >> $HOME/.profile; \
 	# Composer based dependencies
-	# Add composer bin directory to PATH
+	# Add composer bin project level and global directories to PATH
+	# Project level comes first and thus takes precedence over the global one
+	echo -e "\n"'export PATH="$PATH:${PROJECT_ROOT:-/var/www}/vendor/bin"' >> $HOME/.profile; \
 	echo -e "\n"'export PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
 	# Reload updated PATH from profile to make composer/drush/etc. visible below
 	. $HOME/.profile; \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -324,7 +324,9 @@ RUN set -e; \
 	# Set drush8 as a global fallback for Drush Launcher
 	echo -e "\n""export DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8" >> $HOME/.profile; \
 	# Composer based dependencies
-	# Add composer bin directory to PATH
+	# Add composer bin project level and global directories to PATH
+	# Project level comes first and thus takes precedence over the global one
+	echo -e "\n"'export PATH="$PATH:${PROJECT_ROOT:-/var/www}/vendor/bin"' >> $HOME/.profile; \
 	echo -e "\n"'export PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
 	# Reload updated PATH from profile to make composer/drush/etc. visible below
 	. $HOME/.profile; \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -324,7 +324,9 @@ RUN set -e; \
 	# Set drush8 as a global fallback for Drush Launcher
 	echo -e "\n""export DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8" >> $HOME/.profile; \
 	# Composer based dependencies
-	# Add composer bin directory to PATH
+	# Add composer bin project level and global directories to PATH
+	# Project level comes first and thus takes precedence over the global one
+	echo -e "\n"'export PATH="$PATH:${PROJECT_ROOT:-/var/www}/vendor/bin"' >> $HOME/.profile; \
 	echo -e "\n"'export PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
 	# Reload updated PATH from profile to make composer/drush/etc. visible below
 	. $HOME/.profile; \


### PR DESCRIPTION
Project level vendor/bin (`/var/www/vendor/bin`) takes precedence over the global one (`/home/docker/.composer/vendor/bin`).

Fixes #234 