### PR TITLE
Change Blackfire agent port to 8307

### DIFF
--- a/7.3/config/php/zz-php.ini
+++ b/7.3/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0

--- a/7.4/config/php/zz-php.ini
+++ b/7.4/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0

--- a/8.0/config/php/zz-php.ini
+++ b/8.0/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0


### PR DESCRIPTION
**Requires https://github.com/docksal/docksal/pull/1552**

Blackfire Agent v2 Docker image now uses port 8307 by default.
Although port 8707 can still be used for BC reasons, this PR changes the target port.

This PR also disables Blackfire Monitoring explicitly as Docksal is a dev platform
