### PR TITLE
PHP 8.1

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -19,7 +19,7 @@ defaults:
 env:
   IMAGE: docksal/cli
   UPSTREAM_IMAGE: debian
-  LATEST_VERSION: '8.0'
+  LATEST_VERSION: '8.1'
   DOCKSAL_VERSION: develop
 
 jobs:
@@ -44,6 +44,10 @@ jobs:
             arch: amd64
             version: '8.0'
           -
+            platform: linux/amd64
+            arch: amd64
+            version: '8.1'
+          -
             platform: linux/arm64
             arch: arm64
             version: '7.3'
@@ -55,6 +59,10 @@ jobs:
             platform: linux/arm64
             arch: arm64
             version: '8.0'
+          -
+            platform: linux/arm64
+            arch: arm64
+            version: '8.1'
 
     env:
       ARCH: ${{ matrix.arch }}
@@ -133,6 +141,10 @@ jobs:
             arch: amd64
             version: '8.0'
           -
+            platform: linux/amd64
+            arch: amd64
+            version: '8.1'
+          -
             platform: linux/arm64
             arch: arm64
             version: '7.3'
@@ -144,6 +156,10 @@ jobs:
             platform: linux/arm64
             arch: arm64
             version: '8.0'
+          -
+            platform: linux/arm64
+            arch: arm64
+            version: '8.1'
 
     env:
       ARCH: ${{ matrix.arch }}
@@ -220,6 +236,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
 
     env:
       VERSION_PREFIX: php

--- a/8.1/.dockerignore
+++ b/8.1/.dockerignore
@@ -1,0 +1,4 @@
+tests
+.dockerignore
+Dockerfile
+Makefile

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,0 +1,524 @@
+FROM php:8.1-fpm-buster as cli
+
+ARG TARGETARCH
+ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+# Prevent services autoload (http://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/)
+RUN set -xe; \
+	echo '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d && chmod +x /usr/sbin/policy-rc.d
+
+# Install basic packages
+RUN set -xe; \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
+		apt-transport-https \
+		# ca-certificates and curl come from upstream
+		#ca-certificates \
+		#curl \
+		gnupg \
+		locales \
+		wget \
+	;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# Set en_US.UTF-8 as the default locale
+RUN set -xe; \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LC_ALL en_US.utf8
+
+# Enable additional repos
+RUN set -xe; \
+	sed -i 's/main/main contrib non-free/' /etc/apt/sources.list; \
+	# blackfire.io repo
+	curl -fsSL https://packages.blackfire.io/gpg.key | apt-key add -; \
+	echo "deb https://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list; \
+	# git-lfs repo
+	curl -fsSL https://packagecloud.io/github/git-lfs/gpgkey | apt-key add -; \
+	echo 'deb https://packagecloud.io/github/git-lfs/debian buster main' | tee /etc/apt/sources.list.d/github_git-lfs.list;
+
+# Additional packages
+RUN set -xe; \
+	# Create man direcotries, otherwise some packages may not install (e.g. postgresql-client)
+	# This should be a temporary workaround until fixed upstream: https://github.com/debuerreotype/debuerreotype/issues/10
+	mkdir -p /usr/share/man/man1 /usr/share/man/man7; \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
+		cron \
+		dnsutils \
+		git \
+		git-lfs \
+		ghostscript \
+		# html2text binary - used for self-testing (php-fpm)
+		html2text \
+		imagemagick \
+		iputils-ping \
+		less \
+		# cgi-fcgi binary - used for self-testing (php-fpm)
+		libfcgi-bin \
+		mc \
+		msmtp \
+		# Debian 10 ships with MariaDB instead of MySQL
+		mariadb-client \
+		nano \
+		openssh-client \
+		openssh-server \
+		postgresql-client \
+		procps \
+		pv \
+		rsync \
+		sudo \
+		supervisor \
+		unzip \
+		webp \
+		zip \
+	;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*
+
+RUN set -xe; \
+	# Create a regular user/group "docker" (uid = 1000, gid = 1000 )
+	useradd -m -s /bin/bash -u 1000 -U -p docker docker; \
+	# Give the docker user sudo access
+	usermod -a -G sudo docker; \
+	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+ENV GOSU_VERSION=1.12 \
+	GOMPLATE_VERSION=3.9.0
+RUN set -xe; \
+	# Install gosu and give access to the docker user primary group to use it.
+	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
+	# https://github.com/tianon/gosu
+	curl -fsSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${TARGETARCH} -o /usr/local/bin/gosu; \
+	chown root:$(id -gn docker) /usr/local/bin/gosu; \
+	chmod +sx /usr/local/bin/gosu; \
+	# gomplate (to process configuration templates in startup.sh)
+	curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-${TARGETARCH} -o /usr/local/bin/gomplate; \
+	chmod +x /usr/local/bin/gomplate
+
+# Configure sshd (for use PHPStorm's remote interpreters and tools integrations)
+# http://docs.docker.com/examples/running_ssh_service/
+RUN set -xe; \
+	mkdir /var/run/sshd; \
+	echo 'docker:docker' | chpasswd; \
+	sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config; \
+	# SSH login fix. Otherwise user is kicked off after login
+	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
+	echo "export VISIBLE=now" >> /etc/profile
+ENV NOTVISIBLE "in users profile"
+
+# PHP
+RUN set -xe; \
+	# Note: essential build tools (g++, gcc, make, etc) are included upstream as persistent packages.
+	# See https://github.com/docker-library/php/blob/406fcd31e62d633f62ac0d7bc5fc29aa1b3929fc/7.2/buster/fpm/Dockerfile#L18-L40
+	buildDeps=" \
+		libc-client2007e-dev \
+		libfreetype6-dev \
+		libgpgme11-dev \
+		libicu-dev \
+		libjpeg62-turbo-dev \
+		libkrb5-dev \
+		libldap2-dev \
+		libmagickcore-dev \
+		libmagickwand-dev \
+		libmemcached-dev \
+		libmhash-dev \
+		libpng-dev \
+		libpq-dev \
+		libwebp-dev \
+		libssh2-1-dev \
+		libxpm-dev \
+		libxslt1-dev \
+		libzip-dev \
+		unixodbc-dev \
+	"; \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
+		$buildDeps \
+		blackfire-php \
+		libc-client2007e \
+		libfreetype6 \
+		libgpgme11 \
+		libicu63 \
+		libjpeg62-turbo \
+		libldap-2.4-2 \
+		libmagickcore-6.q16-*-extra \
+		libmagickwand-6.q16-6 \
+		libmemcached11 \
+		libmemcachedutil2 \
+		libmhash2 \
+		libpng16-16 \
+		libpq5 \
+		libssh2-1 \
+		libxpm4 \
+		libxslt1.1 \
+		libzip4 \
+	;\
+	docker-php-ext-configure >/dev/null gd \
+		--with-freetype \
+		--with-jpeg \
+		--with-webp \
+		--with-xpm; \
+	PHP_OPENSSL=yes docker-php-ext-configure >/dev/null imap --with-kerberos --with-imap-ssl; \
+	# Using $(uname -m) (returns x86_64 / aarch64) vs ${TARGETARCH} (returns amd64 / arm64)
+	docker-php-ext-configure >/dev/null ldap --with-libdir=lib/$(uname -m)-linux-gnu/; \
+	docker-php-ext-configure >/dev/null pgsql --with-pgsql=/usr/local/pgsql/; \
+	docker-php-ext-configure >/dev/null zip; \
+	\
+	docker-php-ext-install >/dev/null -j$(nproc) \
+		bcmath \
+		bz2 \
+		calendar\
+		exif \
+		gd \
+		gettext \
+		imap \
+		intl \
+		ldap \
+		mysqli \
+		opcache \
+		pcntl \
+		pdo_mysql \
+		pdo_pgsql \
+		pgsql \
+		soap \
+		sockets \
+		xsl \
+		zip \
+		sysvsem \
+	;\
+	pecl update-channels; \
+	pecl install >/dev/null </dev/null \
+		apcu \
+		gnupg \
+		imagick \
+		memcached \
+		redis \
+		ssh2-beta \
+		xdebug \
+		xhprof \
+	;\
+	docker-php-ext-enable \
+		apcu \
+		gnupg \
+		imagick \
+		memcached \
+		redis \
+		ssh2 \
+	;\
+	# Cleanup
+	docker-php-source delete; \
+	rm -rf /tmp/pear ~/.pearrc; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
+	apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# Packages not available for arm64
+RUN set -xe; \
+	if [ "${TARGETARCH}" = "amd64" ]; then \
+		# MSQSQL repo - msodbcsql17, pecl/sqlsrv and pecl/pdo_sqlsrv (PHP 7.0+ only)
+		curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -; \
+		echo 'deb https://packages.microsoft.com/debian/10/prod buster main' | tee /etc/apt/sources.list.d/mssql.list; \
+		\
+		buildDeps=" \
+			unixodbc-dev \
+		"; \
+		apt-get update >/dev/null; \
+		# Necessary for msodbcsql17 (MSSQL)
+		ACCEPT_EULA=Y \
+		apt-get -y --no-install-recommends install >/dev/null \
+			$buildDeps \
+			msodbcsql17 \
+		;\
+		pecl update-channels; \
+		pecl install >/dev/null </dev/null \
+			pdo_sqlsrv \
+			sqlsrv \
+		;\
+		docker-php-ext-enable \
+			pdo_sqlsrv \
+			sqlsrv \
+		;\
+		# Cleanup
+		rm -rf /tmp/pear ~/.pearrc; \
+		apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps >/dev/null; \
+		apt-get clean; rm -rf /var/lib/apt/lists/*; \
+	fi
+
+# PHP tools (installed globally)
+ENV COMPOSER_DEFAULT_VERSION=2 \
+	COMPOSER_VERSION=1.10.23 \
+	COMPOSER2_VERSION=2.1.14 \
+	DRUSH_VERSION=8.4.8 \
+	DRUSH_LAUNCHER_VERSION=0.9.1 \
+	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
+	WPCLI_VERSION=2.5.0 \
+	BLACKFIRE_VERSION=1.49.3 \
+	PLATFORMSH_CLI_VERSION=3.72.0 \
+	ACQUIA_CLI_VERSION=1.19.0 \
+	TERMINUS_VERSION=2.6.0 \
+	JQ_VERSION=1.6 \
+	YQ_VERSION=4.16.1
+RUN set -xe; \
+	# Composer 1.x
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
+	# Composer 2.x
+	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER2_VERSION}/composer.phar" -o /usr/local/bin/composer2; \
+	# Drush 8 (global fallback)
+	curl -fsSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8; \
+	# Drush Launcher
+	curl -fsSL "https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VERSION}/drush.phar" -o /usr/local/bin/drush; \
+	# Drupal Console Launcher
+	curl -fsSL "https://github.com/hechoendrupal/drupal-console-launcher/releases/download/${DRUPAL_CONSOLE_LAUNCHER_VERSION}/drupal.phar" -o /usr/local/bin/drupal; \
+	# Wordpress CLI
+	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
+	# Blackfire CLI
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
+	# Platform.sh CLI
+	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	# Acquia CLI
+	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
+	# Pantheon Terminus
+	curl -fsSL "https://github.com/pantheon-systems/terminus/releases/download/${TERMINUS_VERSION}/terminus.phar" -o /usr/local/bin/terminus; \
+	# jq (no arm64)
+	if [ "${TARGETARCH}" = "amd64" ]; then \
+		curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" -o /usr/local/bin/jq; \
+		chmod +x /usr/local/bin/jq; \
+	fi; \
+	# yq
+	curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${TARGETARCH}" -o /usr/local/bin/yq; \
+	# Set Default Composer Version
+	ln -s /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer; \
+	# Make all downloaded binaries executable in one shot
+	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus yq);
+
+# Install Python3 from Debian repos
+# This adds about 30MB to uncompressed image size.
+# TODO: some other dependency in this image installs python2. Which one?
+RUN set -xe; \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
+		python3 \
+	;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# Install Ruby from Debian repos
+RUN set -xe; \
+	apt-get update >/dev/null; \
+	apt-get -y --no-install-recommends install >/dev/null \
+		ruby-full \
+	;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*
+
+# All further RUN commands will run as the "docker" user
+USER docker
+SHELL ["/bin/bash", "-c"]
+
+# Don't use -x here, as the output may be excessive
+RUN set -e; \
+	\
+	# Set drush8 as a global fallback for Drush Launcher
+	echo -e "\n""export DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8" >> $HOME/.profile; \
+	# Composer based dependencies
+	# Add composer bin project level and global directories to PATH
+	# Project level comes first and thus takes precedence over the global one
+	echo -e "\n"'export PATH="$PATH:${PROJECT_ROOT:-/var/www}/vendor/bin"' >> $HOME/.profile; \
+	echo -e "\n"'export PATH="$PATH:$HOME/.composer/vendor/bin"' >> $HOME/.profile; \
+	# Reload updated PATH from profile to make composer/drush/etc. visible below
+	. $HOME/.profile; \
+	# Drupal Coder & WP Coding Standards w/ a matching version of PHP_CodeSniffer
+	composer global require drupal/coder wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp >/dev/null; \
+	# Don't fix the indentation or installed_paths will not be set correctly
+	phpcs --config-set installed_paths \
+$HOME/.composer/vendor/drupal/coder/coder_sniffer/,\
+$HOME/.composer/vendor/wp-coding-standards/wpcs/,\
+$HOME/.composer/vendor/phpcompatibility/php-compatibility/PHPCompatibility/,\
+$HOME/.composer/vendor/phpcompatibility/phpcompatibility-wp/PHPCompatibilityWP,\
+$HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibilityParagonieRandomCompat; \
+	# Cleanup
+	composer clear-cache
+
+# Node.js (installed as user)
+ENV \
+	NVM_VERSION=0.38.0 \
+	NODE_VERSION=14.17.3 \
+	YARN_VERSION=1.22.10
+# Don't use -x here, as the output may be excessive
+RUN set -e; \
+	# NVM and a defaut Node.js version
+	export PROFILE="$HOME/.profile"; \
+	curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash >/dev/null; \
+	# Reload profile to load nvm (needed by Yarn installation below)
+	. $HOME/.profile; \
+	# Yarn
+	export YARN_PROFILE="$HOME/.profile"; \
+	curl -fsSL https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION} >/dev/null
+
+## Ruby (installed as user) via rvm
+## Note: Disabled. rvm + its build dependecies bloat the image (~80MB)
+## Debian 10 ships with Ruby 2.5, so we'll stick with that by default.
+## It is still possible for the end user to switch to a different Ruby version via rvm.
+#ENV \
+#	RVM_VERSION_INSTALL=1.29.10 \
+#	RUBY_VERSION_INSTALL=2.7.2
+## Don't use -x here, as the output may be excessive
+#RUN set -e; \
+#	# Export ruby gem bin path
+#	echo 'export PATH=$PATH:$(ruby -r rubygems -e "puts Gem.user_dir")/bin' >> $HOME/.profile; \
+#	. $HOME/.profile; \
+#	# Public GPG servers are not realiable, so downloading keys from rvm.io instead.
+#	#gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+#	# Import and trust rvm keys
+#	# mpapis@gmail.com
+#	curl -sSL https://rvm.io/mpapis.asc | gpg --batch --import -; \
+#	echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --batch --import-ownertrust; \
+#	# piotr.kuczynski@gmail.com
+#	curl -sSL https://rvm.io/pkuczynski.asc | gpg --batch --import -; \
+#	echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --batch --import-ownertrust; \
+#	\
+#	echo 'rvm_autoupdate_flag=0' >> $HOME/.rvmrc; \
+#	echo 'rvm_silence_path_mismatch_check_flag=1' >> $HOME/.rvmrc; \
+#	curl -fsSL https://raw.githubusercontent.com/rvm/rvm/${RVM_VERSION_INSTALL}/binscripts/rvm-installer | bash -s -- --ignore-dotfiles --version ${RVM_VERSION_INSTALL}; \
+#	{ \
+#		echo ''; \
+#		echo 'export PATH="$PATH:$HOME/.rvm/bin"'; \
+#		echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"'; \
+#	} >> $HOME/.profile; \
+#	# Reload $HOME/.profile to apply settings for the current shell
+#	. $HOME/.profile; \
+#	\
+#	# rvm.io does not currently have ruby binaries for Debian 9, so Ruby is compiled from source, which requires a bunch
+#	# of extra dependencies installed (rvm installs these automatically), which bloat this image:
+#	# rvm/ruby required packages: gawk, automake, bison, libffi-dev, libgdbm-dev, libncurses5-dev, libsqlite3-dev, libtool, libyaml-dev, sqlite3, zlib1g-dev, libgmp-dev, libreadline-dev, libssl-dev
+#	rvm install ruby-${RUBY_VERSION_INSTALL}; \
+#	rvm use ruby-${RUBY_VERSION_INSTALL} --default; \
+#	\
+#	gem install --user-install bundler; \
+#	# Have bundler install gems locally (./.bundle) by default
+#	echo -e "\n"'export BUNDLE_PATH=.bundle' >> $HOME/.profile; \
+#	\
+#	rvm cleanup all; \
+#	rvm gemset globalcache enable
+
+# Python (installed as user) via pyenv
+# Note: Disabled. pyenv + its build dependecies bloat the image (~300MB).
+# Debian 10 ships with Python 3.7, so we'll stick with that by default.
+# It is still possible for the end user to switch to a different python version via pyenv.
+#ENV \
+#	PYENV_VERSION_INSTALL=1.2.21 \
+#	PYTHON_VERSION_INSTALL=3.8.3
+#RUN set -xe; \
+#	# pyenv requires a bunch of build dependencies installed, which would bloat this image
+#	# See https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
+#	sudo apt-get update >/dev/null; \
+#	sudo apt-get -y --no-install-recommends install >/dev/null \
+#		build-essential libssl-dev zlib1g-dev libbz2-dev \
+#		libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+#		xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
+#	;\
+#	# Cleanup
+#	sudo apt-get clean; sudo rm -rf /var/lib/apt/lists/*; \
+#	\
+#	git clone --depth 1 -b v${PYENV_VERSION_INSTALL} https://github.com/pyenv/pyenv.git $HOME/.pyenv; \
+#	rm -rf $HOME/.pyenv/.git; \
+#	{ \
+#		echo ''; \
+#		echo 'export PYENV_ROOT="$HOME/.pyenv"'; \
+#		echo 'export PATH="$PYENV_ROOT/bin:$PATH"'; \
+#		echo 'eval "$(pyenv init -)"'; \
+#	} >> $HOME/.profile; \
+#	# Reload $HOME/.profile to apply settings for the current shell
+#	. $HOME/.profile; \
+#	pyenv install ${PYTHON_VERSION_INSTALL}; \
+#	pyenv global ${PYTHON_VERSION_INSTALL}
+
+# Notify web container about started fin exec
+RUN echo '(/opt/ping-web.sh &)' >> $HOME/.profile
+
+USER root
+SHELL ["/bin/sh", "-c"]
+
+# Copy configs and scripts
+COPY --chown=docker:docker config/.terminus /home/docker/.terminus
+COPY --chown=docker:docker config/.ssh /home/docker/.ssh
+COPY config/supervisor /etc/supervisor/conf.d
+COPY startup.sh /opt/startup.sh
+COPY healthcheck.sh /opt/healthcheck.sh
+COPY ping-web.sh /opt/ping-web.sh
+# PHP default settings, global overrides and fpm overrides
+# PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
+# TODO: For now, will just hardcode a specific version available on https://github.com/php/php-src/
+ADD https://raw.githubusercontent.com/php/php-src/PHP-8.0.5/php.ini-development /usr/local/etc/php/php.ini
+COPY config/php/zz-php.ini /usr/local/etc/php/conf.d/zz-php.ini
+COPY config/php/xdebug.ini /opt/docker-php-ext-xdebug.ini
+COPY config/php/xhprof.ini /opt/docker-php-ext-xhprof.ini
+COPY config/php/opcache.ini /opt/docker-php-ext-opcache.ini
+COPY config/php/zz-php-fpm.conf /usr/local/etc/php-fpm.d/zz-php-fpm.conf
+
+ENV \
+	# ssh-agent proxy socket (requires docksal/ssh-agent)
+	SSH_AUTH_SOCK=/.ssh-agent/proxy-socket \
+	# Set TERM so text editors/etc. can be used
+	TERM=xterm \
+	# Allow PROJECT_ROOT to be universally used in fin custom commands (inside and outside cli)
+	PROJECT_ROOT=/var/www \
+	# Default values for HOST_UID and HOST_GUI to match the default Ubuntu user. These are used in startup.sh
+	HOST_UID=1000 \
+	HOST_GID=1000 \
+	# Delay in seconds between pings web from cli, while running fin exec. 0 - disabled
+	WEB_KEEPALIVE=0 \
+	# xdebug disabled by default
+	XDEBUG_ENABLED=0 \
+	XHPROF_ENABLED=0 \
+	XHPROF_OUTPUT_DIR=/tmp/xhprof
+
+# TODO: [v3] remove and set these via docker-compose
+EXPOSE 9000
+EXPOSE 22
+EXPOSE 3000
+
+WORKDIR /var/www
+
+# Starter script
+ENTRYPOINT ["/opt/startup.sh"]
+
+# By default, launch supervisord to keep the container running.
+CMD ["supervisord"]
+
+# Health check script
+HEALTHCHECK --interval=5s --timeout=1s --retries=12 CMD ["/opt/healthcheck.sh"]
+
+
+# Visual Studio Code Server flavor
+FROM cli as code-server
+
+# Run as docker, so we don't have to fix permissions
+USER docker
+
+ARG HOME=/home/docker
+
+ENV \
+	CODE_SERVER_VERSION=3.11.0 \
+	VSCODE_XDEBUG_VERSION=1.16.1 \
+	VSCODE_GITLENS_VERSION=11.6.0 \
+	VSCODE_HOME="${HOME}/code-server"
+
+# Install code-server
+RUN set -xe; \
+	curl -fsSL "https://github.com/cdr/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${TARGETARCH}.deb" -o /tmp/code-server_${TARGETARCH}.deb; \
+	sudo dpkg -i /tmp/code-server_${TARGETARCH}.deb; \
+	rm -rf /tmp/*.*
+
+# Settings
+COPY --chown=docker:docker config/code-server ${VSCODE_HOME}
+
+# Install extensions
+# Note: Have to use --user-data-dir with --install-extension instead of --config
+RUN set -xe; \
+	code-server --user-data-dir=${VSCODE_HOME} --install-extension eamodio.gitlens@11.6.0; \
+	code-server --user-data-dir=${VSCODE_HOME} --install-extension felixfbecker.php-debug@1.16.1
+
+# Switch back to root (IMPORTANT!)
+USER root

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -191,7 +191,7 @@ RUN set -xe; \
 	pecl update-channels; \
 	pecl install >/dev/null </dev/null \
 		apcu \
-		gnupg \
+		#gnupg \ # Not compatible with PHP 8.1
 		imagick \
 		memcached \
 		redis \
@@ -201,7 +201,7 @@ RUN set -xe; \
 	;\
 	docker-php-ext-enable \
 		apcu \
-		gnupg \
+		#gnupg \ # Not compatible with PHP 8.1
 		imagick \
 		memcached \
 		redis \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -231,9 +231,10 @@ RUN set -xe; \
 			msodbcsql17 \
 		;\
 		pecl update-channels; \
+		# TODO: Using beta. Switch to stable once PHP 8.1 support is finalized.
 		pecl install >/dev/null </dev/null \
-			pdo_sqlsrv \
-			sqlsrv \
+			pdo_sqlsrv-beta \
+			sqlsrv-beta \
 		;\
 		docker-php-ext-enable \
 			pdo_sqlsrv \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -450,7 +450,7 @@ COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
 # PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
 # TODO: For now, will just hardcode a specific version available on https://github.com/php/php-src/
-ADD https://raw.githubusercontent.com/php/php-src/PHP-8.0.5/php.ini-development /usr/local/etc/php/php.ini
+ADD https://raw.githubusercontent.com/php/php-src/PHP-8.1.0/php.ini-development /usr/local/etc/php/php.ini
 COPY config/php/zz-php.ini /usr/local/etc/php/conf.d/zz-php.ini
 COPY config/php/xdebug.ini /opt/docker-php-ext-xdebug.ini
 COPY config/php/xhprof.ini /opt/docker-php-ext-xhprof.ini

--- a/8.1/Makefile
+++ b/8.1/Makefile
@@ -1,0 +1,76 @@
+-include ../tests/env_make
+-include env_make
+
+IMAGE ?= docksal/cli
+VERSION_PREFIX ?= php
+VERSION ?= 8.1
+BUILD_IMAGE_TAG ?= $(IMAGE):$(VERSION_PREFIX)$(VERSION)-build
+NAME = docksal-cli-$(VERSION)-$(GIT_SHA7)
+CWD = $(shell pwd)
+
+# Improve write performance for /home/docker by turning it into a volume
+VOLUMES = -v /home/docker
+
+.EXPORT_ALL_VARIABLES:
+
+.PHONY: build exec test push shell run start stop logs clean release
+
+default: build
+
+build:
+	docker build -t $(BUILD_IMAGE_TAG) .
+
+# See https://docs.docker.com/buildx/working-with-buildx/
+# See https://github.com/docker/buildx
+buildx:
+	docker buildx build --tag $(BUILD_IMAGE_TAG) .
+buildx-with-cache:
+	docker buildx build --cache-from=type=registry,ref=$(BUILD_IMAGE_TAG) --cache-to=type=inline --tag=$(BUILD_IMAGE_TAG) .
+
+test:
+	NAME=$(NAME) VERSION=$(VERSION) ../tests/test.bats
+
+push:
+	docker push $(BUILD_IMAGE_TAG)
+
+run: clean
+	docker run --rm --name $(NAME) -it $(PORTS) $(VOLUMES) $(ENV) $(BUILD_IMAGE_TAG)
+
+# Copy files into container instead of mounting from the host at runtime.
+# This allows running tests on a remote docker instance.
+start: clean
+	docker create --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(BUILD_IMAGE_TAG)
+	docker cp ../tests/. $(NAME):/var/www/
+	docker start $(NAME)
+
+# Only copy docroot (not config overrides)
+start-bare: clean
+	docker create --name $(NAME) $(PORTS) $(VOLUMES) $(ENV) $(BUILD_IMAGE_TAG)
+	docker cp ../tests/docroot/. $(NAME):/var/www/docroot/
+	docker start $(NAME)
+
+# Non-interactive and non-tty docker exec (uses LF instead of CRLF line endings)
+exec:
+	@docker exec -u docker $(NAME) bash -lc "$(CMD)"
+
+# Interactive docker exec
+exec-it:
+	@docker exec -u docker -it $(NAME) bash -ilc "$(CMD)"
+
+shell:
+	@docker exec -u docker -it $(NAME) bash -il
+
+stop:
+	docker stop $(NAME)
+
+logs:
+	docker logs $(NAME)
+
+logs-follow:
+	docker logs -f $(NAME)
+
+clean:
+	docker rm -vf $(NAME) >/dev/null 2>&1 || true
+
+tags:
+	@../.github/scripts/docker-tags.sh

--- a/8.1/config/.ssh/config
+++ b/8.1/config/.ssh/config
@@ -1,0 +1,5 @@
+# Disable remote host key checking and warnings
+Host *
+   StrictHostKeyChecking no
+   UserKnownHostsFile /dev/null
+   LogLevel ERROR

--- a/8.1/config/.ssh/id_rsa.tmpl
+++ b/8.1/config/.ssh/id_rsa.tmpl
@@ -1,0 +1,1 @@
+{{ getenv "SECRET_SSH_PRIVATE_KEY" | base64.Decode }}

--- a/8.1/config/.terminus/config.yml
+++ b/8.1/config/.terminus/config.yml
@@ -1,0 +1,2 @@
+hide_update_message: true
+hide_git_mode_warning: true

--- a/8.1/config/code-server/User/settings.json
+++ b/8.1/config/code-server/User/settings.json
@@ -1,0 +1,37 @@
+{
+  // XDebug Launch Configuration settings
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      // Listener mode (recommended for most cases)
+      // Can be used to debug both: web and cli PHP sessions.
+      {
+        "name": "XDebug (listener)",
+        "type": "php",
+        "request": "launch",
+        "port": 9000
+      },
+      // Current script mode
+      // Note: IDE launches the script inside of the ide container and not the cli container.
+      {
+        "name": "XDebug (currently open script)",
+        "type": "php",
+        "request": "launch",
+        "program": "${file}",
+        "cwd": "${fileDirname}",
+        "port": 9000
+      }
+    ]
+  },
+  // File associations
+  "files.associations": {
+    "*.inc": "php",
+    "*.module": "php",
+    "*.install": "php",
+    "*.theme": "php",
+    "*.tpl.php": "php",
+    "*.test": "php",
+    "*.php": "php"
+  },
+  "workbench.colorTheme": "Default Dark+"
+}

--- a/8.1/config/code-server/config.yaml.tmpl
+++ b/8.1/config/code-server/config.yaml.tmpl
@@ -1,0 +1,9 @@
+user-data-dir: {{ getenv "VSCODE_HOME" }}
+bind-addr: 0.0.0.0:8080
+cert: false
+{{ if (getenv "IDE_PASSWORD") }}
+auth: password
+password: {{ getenv "IDE_PASSWORD" }}
+{{ else }}
+auth: none
+{{ end }}

--- a/8.1/config/php/opcache.ini
+++ b/8.1/config/php/opcache.ini
@@ -1,0 +1,3 @@
+; Extention settings
+[opcache]
+opcache.preload=/var/www/.docksal/etc/php/preload.php

--- a/8.1/config/php/xdebug.ini
+++ b/8.1/config/php/xdebug.ini
@@ -1,0 +1,12 @@
+[xdebug]
+zend_extension=xdebug.so
+; See https://xdebug.org/docs/all_settings#mode
+xdebug.mode=debug
+; xdebug.xdebug.client_host defaults to "localhost", which works with VS Code Server web IDE running locally
+; For debugging from a "remote" host, xdebug.xdebug.client_host is set to ${DOCKSAL_HOST_IP} at runtime
+; xdebug.xdebug.client_port defaults to "9003" in Xdebug 3. We use 9000 instead for backward compatibility with Xdebug 2.
+xdebug.client_port=9000
+; TODO: Why do we have to set this?
+xdebug.idekey=xdebug_session
+; Increase max_nesting_level to support complex Drupal pages (default is 100)
+xdebug.max_nesting_level=256

--- a/8.1/config/php/xhprof.ini
+++ b/8.1/config/php/xhprof.ini
@@ -1,0 +1,2 @@
+[xhprof]
+extension="xhprof.so"

--- a/8.1/config/php/zz-php-fpm.conf
+++ b/8.1/config/php/zz-php-fpm.conf
@@ -1,0 +1,19 @@
+; PHP-FPM settings
+
+[global]
+; This pid file is used for Docker healthcheck
+pid = /run/php-fpm.pid
+
+[www]
+user = docker
+catch_workers_output = yes
+listen = 0.0.0.0:9000
+clear_env = no
+
+; PHP (FPM) settings
+; See zz-php.ini for global (CLI and FPM) PHP settings
+php_value[memory_limit] = 256M
+php_value[max_execution_time] = 300
+php_value[upload_max_filesize] = 500M
+php_value[post_max_size] = 500M
+php_value[max_input_vars] = 2000

--- a/8.1/config/php/zz-php.ini
+++ b/8.1/config/php/zz-php.ini
@@ -1,0 +1,18 @@
+; PHP global (CLI and FPM) settings
+; To override settings for FPM use zz-php-fpm.conf
+[php]
+memory_limit = -1
+max_execution_time = 600
+date.timezone = UTC
+display_errors = On
+display_startup_errors = On
+
+[mail]
+; Enable Mailhog integration by default
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+
+; Extention settings
+[opcache]
+opcache.memory_consumption = 128
+[blackfire]
+blackfire.agent_socket = 'tcp://blackfire:8707'

--- a/8.1/config/supervisor/supervisord-code-server.conf.tmpl
+++ b/8.1/config/supervisor/supervisord-code-server.conf.tmpl
@@ -1,0 +1,6 @@
+# VS Code Server web IDE
+[program:code-server]
+# Using bash -lc here to load docker user profile (necessary for nvn/node to initialize)
+command = gosu docker bash -lc '/usr/bin/code-server --config=${VSCODE_HOME}/config.yaml /var/www'
+stdout_logfile = /var/log/supervisor/code-server-stdout
+stderr_logfile = /var/log/supervisor/code-server-stderr

--- a/8.1/config/supervisor/supervisord-crond.conf
+++ b/8.1/config/supervisor/supervisord-crond.conf
@@ -1,0 +1,5 @@
+[program:cron]
+# Cron will only log to syslog and nothing else...
+command = /usr/sbin/cron -f
+stdout_logfile = /var/log/supervisor/cron-stdout
+stderr_logfile = /var/log/supervisor/cron-stderr

--- a/8.1/config/supervisor/supervisord-php-fpm.conf
+++ b/8.1/config/supervisor/supervisord-php-fpm.conf
@@ -1,0 +1,4 @@
+[program:php-fpm]
+command = /usr/local/sbin/php-fpm
+stdout_logfile = /var/log/supervisor/php-fpm-stdout
+stderr_logfile = /var/log/supervisor/php-fpm-stderr

--- a/8.1/config/supervisor/supervisord-sshd.conf
+++ b/8.1/config/supervisor/supervisord-sshd.conf
@@ -1,0 +1,4 @@
+[program:sshd]
+command = /usr/sbin/sshd -D
+stdout_logfile = /var/log/supervisor/sshd-stdout
+stderr_logfile = /var/log/supervisor/sshd-stderr

--- a/8.1/config/supervisor/supervisord.conf
+++ b/8.1/config/supervisor/supervisord.conf
@@ -1,0 +1,6 @@
+[supervisord]
+nodaemon = true
+# debug prints output from all services to stdout/stderr.
+# This way logs can be reviewed with docker logs.
+# Additionalluy, logs from specific services are forwarded to individual files on disk.
+loglevel = debug

--- a/8.1/healthcheck.sh
+++ b/8.1/healthcheck.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Initialization phase in startup.sh is complete
+[[ -f /var/run/cli ]] || exit 1
+
+# supervisor services are running
+if [[ -f /run/supervisord.pid ]]; then
+	if [[ "${IDE_ENABLED}" == "1" ]]; then
+		# IDE mode
+		ps aux | grep code-server >/dev/null || exit 1
+	else
+		# php-fpm/cli mode
+		[[ -f /run/php-fpm.pid ]] || exit 1
+		[[ -f /run/sshd.pid ]] || exit 1
+	fi
+fi

--- a/8.1/ping-web.sh
+++ b/8.1/ping-web.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Notify web container about started fin exec
+if [[ "${WEB_KEEPALIVE}" != "0" ]] && [[ "${VIRTUAL_HOST}" != "" ]]
+then
+	while true
+	do
+		curl -s -m 1 ${VIRTUAL_HOST}/exec_in_progress_inside_cli >/dev/null 2>&1
+		sleep ${WEB_KEEPALIVE}
+	done
+fi

--- a/8.1/startup.sh
+++ b/8.1/startup.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+# This script is running as root by default.
+# Switching to the docker user can be done via "gosu docker <command>".
+
+HOME_DIR='/home/docker'
+
+DEBUG=${DEBUG:-0}
+# Turn debugging ON when cli is started in the service mode
+[[ "$1" == "supervisord" ]] && DEBUG=1
+echo-debug ()
+{
+	[[ "$DEBUG" != 0 ]] && echo "$(date +"%F %H:%M:%S") | $@"
+}
+
+uid_gid_reset ()
+{
+	if [[ "$HOST_UID" != "$(id -u docker)" ]] || [[ "$HOST_GID" != "$(id -g docker)" ]]; then
+		echo-debug "Updating docker user uid/gid to $HOST_UID/$HOST_GID to match the host user uid/gid..."
+		usermod -u "$HOST_UID" -o docker
+		groupmod -g "$HOST_GID" -o "$(id -gn docker)"
+	fi
+}
+
+xdebug_enable ()
+{
+	echo-debug "Enabling xdebug..."
+	ln -s /opt/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/
+}
+
+xhprof_enable ()
+{
+	echo-debug "Enabling xhprof..."
+	cp /opt/docker-php-ext-xhprof.ini /usr/local/etc/php/conf.d/
+	# Output directory to the ini file
+	echo "xhprof.output_dir = ${XHPROF_OUTPUT_DIR}" >> /usr/local/etc/php/conf.d/docker-php-ext-xhprof.ini
+	# Try to create directory if it doesn't exist
+	mkdir ${XHPROF_OUTPUT_DIR} || true
+	# Change owner of directory
+	chown docker:docker ${XHPROF_OUTPUT_DIR}
+}
+
+opcache_preload_enable()
+{
+	echo-debug "Enabling opcache preload..."
+	ln -s /opt/docker-php-ext-opcache.ini /usr/local/etc/php/conf.d/
+}
+
+ide_mode_enable ()
+{
+	echo-debug "Enabling web IDE..."
+	# Enabled only code-server service (disabled all other services)
+	# TODO: split IDE/cli and php-fpm entirely
+	rm -f /etc/supervisor/conf.d/supervisord-*.conf
+	render_tmpl "/etc/supervisor/conf.d/supervisord-code-server.conf"
+	render_tmpl "${VSCODE_HOME}/config.yaml"
+}
+
+# Creates symlinks to project level overrides if they exist
+php_settings ()
+{
+	php_ini=/var/www/.docksal/etc/php/php.ini
+	if [[ -f ${php_ini} ]]; then
+		echo-debug "Found project level overrides for PHP. Including:"
+		echo-debug "${php_ini}"
+		ln -s /var/www/.docksal/etc/php/php.ini /usr/local/etc/php/conf.d/zzz-php.ini
+	fi
+
+	php_fpm_conf=/var/www/.docksal/etc/php/php-fpm.conf
+	if [[ -f ${php_fpm_conf} ]]; then
+		echo-debug "Found project level overrides for PHP-FPM. Including:"
+		echo-debug "${php_fpm_conf}"
+		ln -s ${php_fpm_conf} /usr/local/etc/php-fpm.d/zzz-php-fpm.conf
+	fi
+}
+
+add_ssh_key ()
+{
+	echo-debug "Adding a private SSH key from SECRET_SSH_PRIVATE_KEY..."
+	render_tmpl "$HOME_DIR/.ssh/id_rsa"
+	chmod 0600 "$HOME_DIR/.ssh/id_rsa"
+}
+
+# Helper function to render configs from go templates using gomplate
+render_tmpl ()
+{
+	local file="${1}"
+	local tmpl="${1}.tmpl"
+
+	if [[ -f "${tmpl}" ]]; then
+		echo-debug "Rendering template: ${tmpl}..."
+		# gomplate started throwing an empty line into stderr in v3.7.0, so we have to mute it below
+		gomplate --file "${tmpl}" --out "${file}" &>/dev/null
+	else
+		echo-debug "Error: Template file not found: ${tmpl}"
+		return 1
+	fi
+}
+
+# Helper function to loop through all environment variables prefixed with SECRET_ and
+# convert to the equivalent variable without SECRET.
+# Example: SECRET_TERMINUS_TOKEN => TERMINUS_TOKEN.
+convert_secrets ()
+{
+	eval 'secrets=(${!SECRET_@})'
+	for secret_key in "${secrets[@]}"; do
+		key=${secret_key#SECRET_}
+		secret_value=${!secret_key}
+
+		# Write new variables to /etc/profile.d/secrets.sh to make them available for all users/sessions
+		echo "export ${key}=\"${secret_value}\"" | tee -a "/etc/profile.d/secrets.sh" >/dev/null
+
+		# Also export new variables here
+		# This makes them available in the server/php-fpm environment
+		eval "export ${key}=${secret_value}"
+	done
+}
+
+# Pantheon (terminus) login
+terminus_login ()
+{
+	echo-debug "Authenticating with Pantheon..."
+	# This has to be done using the docker user via su to load the user environment
+	# Note: Using 'su -l' to initiate a login session and have .profile sourced for the docker user
+	local command="terminus auth:login --machine-token='${TERMINUS_TOKEN}'"
+	local output=$(su -l docker -c "${command}" 2>&1)
+	if [[ $? != 0 ]]; then
+		echo-debug "ERROR: Pantheon authentication failed."
+		echo
+		echo "$output"
+		echo
+	fi
+}
+
+# Acquia CLI login
+acli_login ()
+{
+	echo-debug "Authenticating with Acquia..."
+	# This has to be done using the docker user via su to load the user environment
+	# Note: Using 'su -l' to initiate a login session and have .profile sourced for the docker user
+	local command="acli auth:login --key='${ACQUIA_CLI_KEY}' --secret='${ACQUIA_CLI_SECRET}' --no-interaction"
+	local output=$(su -l docker -c "${command}" 2>&1)
+	if [[ $? != 0 ]]; then
+		echo-debug "ERROR: Acquia authentication failed."
+		echo
+		echo "$output"
+		echo
+	fi
+}
+
+# Git settings
+git_settings ()
+{
+	# These must be run as the docker user
+	echo-debug "Configuring git..."
+	# Set default git settings if none have been passed
+	# See https://github.com/docksal/service-cli/issues/124
+	gosu docker git config --global user.email "${GIT_USER_EMAIL:-cli@docksal.io}"
+	gosu docker git config --global user.name "${GIT_USER_NAME:-Docksal CLI}"
+}
+
+# Inject a private SSH key if provided
+[[ "$SECRET_SSH_PRIVATE_KEY" != "" ]] && add_ssh_key
+
+# Set Composer Version
+[[ "${COMPOSER_DEFAULT_VERSION}" != "" ]] && [[ -f /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} ]] && ln -sf /usr/local/bin/composer${COMPOSER_DEFAULT_VERSION} /usr/local/bin/composer
+
+# Convert all Environment Variables Prefixed with SECRET_
+convert_secrets
+
+# Docker user uid/gid mapping to the host user uid/gid
+[[ "$HOST_UID" != "" ]] && [[ "$HOST_GID" != "" ]] && uid_gid_reset
+
+# Enable xdebug
+[[ "$XDEBUG_ENABLED" != "" ]] && [[ "$XDEBUG_ENABLED" != "0" ]] && xdebug_enable
+
+# Enable xdebug
+[[ "$XHPROF_ENABLED" != "" ]] && [[ "$XHPROF_ENABLED" != "0" ]] && xhprof_enable
+
+# Enable opcache preload
+[[ -f "/var/www/.docksal/etc/php/preload.php" ]] && opcache_preload_enable
+
+# Enable web IDE
+[[ "$IDE_ENABLED" != "" ]] && [[ "$IDE_ENABLED" != "0" ]] && ide_mode_enable
+
+# Include project level PHP settings if found
+php_settings
+
+# Make sure permissions are correct (after uid/gid change and COPY operations in Dockerfile)
+# To not bloat the image size, permissions on the home folder are reset at runtime.
+echo-debug "Resetting permissions on $HOME_DIR and /var/www..."
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" -R "$HOME_DIR"
+# Docker resets the project root folder permissions to 0:0 when cli is recreated (e.g. an env variable updated).
+# We apply a fix/workaround for this at startup (non-recursive).
+chown "${HOST_UID:-1000}:${HOST_GID:-1000}" /var/www
+
+# These have to happen after the home directory permissions are reset,
+# otherwise the docker user may not have write access to /home/docker, where the auth session data is stored.
+# Automatically authenticate with Pantheon if Terminus token is present
+[[ "$TERMINUS_TOKEN" != "" ]] && terminus_login
+
+# Authenticate to Acquia CLI
+[[ "$ACQUIA_CLI_KEY" != "" ]] && [[ "$ACQUIA_CLI_SECRET" != "" ]] && acli_login
+
+# If crontab file is found within project add contents to user crontab file.
+if [[ -f ${PROJECT_ROOT}/.docksal/services/cli/crontab ]]; then
+	echo-debug "Loading crontab..."
+	cat ${PROJECT_ROOT}/.docksal/services/cli/crontab | crontab -u docker -
+fi
+
+# Apply git settings
+[[ "$GIT_USER_EMAIL" != "" ]] && [[ "$GIT_USER_NAME" != "" ]] && git_settings
+
+# Initialization steps completed. Create a pid file to mark the container as healthy
+echo-debug "Preliminary initialization completed."
+touch /var/run/cli
+
+# Execute a custom startup script if present
+if [[ -x ${PROJECT_ROOT}/.docksal/services/cli/startup.sh ]]; then
+	echo-debug "Running custom startup script..."
+	# TODO: should we source the script instead?
+	su -l docker -c "${PROJECT_ROOT}/.docksal/services/cli/startup.sh"
+	if [[ $? == 0 ]]; then
+		echo-debug "Custom startup script executed successfully."
+	else
+		echo-debug "ERROR: Custom startup script execution failed."
+	fi
+fi
+
+# Execute passed CMD arguments
+echo-debug "Passing execution to: $*"
+# Service mode (run as root)
+if [[ "$1" == "supervisord" ]]; then
+	exec gosu root supervisord -c /etc/supervisor/supervisord.conf
+# Command mode (run as docker user)
+else
+	exec gosu docker "$@"
+fi

--- a/8.1/tests/essential-binaries.sh
+++ b/8.1/tests/essential-binaries.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+binaries_amd64=\
+'cat
+convert
+curl
+dig
+g++
+ghostscript
+git
+git-lfs
+gcc
+jq
+html2text
+less
+make
+mc
+more
+mysql
+nano
+nslookup
+ping
+psql
+pv
+rsync
+sudo
+unzip
+wget
+yq
+zip'
+
+binaries_arm64=\
+'cat
+convert
+curl
+dig
+g++
+ghostscript
+git
+git-lfs
+gcc
+html2text
+less
+make
+mc
+more
+mysql
+nano
+nslookup
+ping
+psql
+pv
+rsync
+sudo
+unzip
+wget
+yq
+zip'
+
+# Use the docker reported architecture and not the hosts (uname -m).
+# docker arch may not be the same as hosts's arch (e.g., when using a remote docker instance).
+case "$(docker info -f '{{ .Architecture }}')" in
+	x86_64) echo "${binaries_amd64}" ;;
+	amd64) echo "${binaries_amd64}" ;;
+	aarch64) echo "${binaries_arm64}" ;;
+	arm64) echo "${binaries_arm64}" ;;
+	* ) false;;
+esac

--- a/8.1/tests/php-modules.sh
+++ b/8.1/tests/php-modules.sh
@@ -18,7 +18,6 @@ filter
 ftp
 gd
 gettext
-gnupg
 hash
 iconv
 imagick
@@ -88,7 +87,6 @@ filter
 ftp
 gd
 gettext
-gnupg
 hash
 iconv
 imagick

--- a/8.1/tests/php-modules.sh
+++ b/8.1/tests/php-modules.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+php_modules_amd64=\
+'[PHP Modules]
+apcu
+bcmath
+blackfire
+bz2
+calendar
+Core
+ctype
+curl
+date
+dom
+exif
+fileinfo
+filter
+ftp
+gd
+gettext
+gnupg
+hash
+iconv
+imagick
+imap
+intl
+json
+ldap
+libxml
+mbstring
+memcached
+mysqli
+mysqlnd
+openssl
+pcntl
+pcre
+PDO
+pdo_mysql
+pdo_pgsql
+pdo_sqlite
+pdo_sqlsrv
+pgsql
+Phar
+posix
+readline
+redis
+Reflection
+session
+SimpleXML
+soap
+sockets
+sodium
+SPL
+sqlite3
+sqlsrv
+ssh2
+standard
+sysvsem
+tokenizer
+xml
+xmlreader
+xmlwriter
+xsl
+Zend OPcache
+zip
+zlib
+
+[Zend Modules]
+Zend OPcache
+blackfire
+'
+
+php_modules_arm64=\
+'[PHP Modules]
+apcu
+bcmath
+blackfire
+bz2
+calendar
+Core
+ctype
+curl
+date
+dom
+exif
+fileinfo
+filter
+ftp
+gd
+gettext
+gnupg
+hash
+iconv
+imagick
+imap
+intl
+json
+ldap
+libxml
+mbstring
+memcached
+mysqli
+mysqlnd
+openssl
+pcntl
+pcre
+PDO
+pdo_mysql
+pdo_pgsql
+pdo_sqlite
+pgsql
+Phar
+posix
+readline
+redis
+Reflection
+session
+SimpleXML
+soap
+sockets
+sodium
+SPL
+sqlite3
+ssh2
+standard
+sysvsem
+tokenizer
+xml
+xmlreader
+xmlwriter
+xsl
+Zend OPcache
+zip
+zlib
+
+[Zend Modules]
+Zend OPcache
+blackfire
+'
+
+# Use the docker reported architecture and not the hosts (uname -m).
+# docker arch may not be the same as hosts's arch (e.g., when using a remote docker instance).
+case "$(docker info -f '{{ .Architecture }}')" in
+	x86_64) echo "${php_modules_amd64}" ;;
+	amd64) echo "${php_modules_amd64}" ;;
+	aarch64) echo "${php_modules_arm64}" ;;
+	arm64) echo "${php_modules_arm64}" ;;
+	* ) false;;
+esac

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile
 #
-DIRS = 7.3 7.4 8.0
+DIRS = 7.3 7.4 8.0 8.1
 # the sets of directories to do various things in
 BUILDDIRS = $(DIRS:%=build-%)
 INSTALLDIRS = $(DIRS:%=install-%)

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -227,9 +227,9 @@ _healthcheck_wait ()
 	unset output
 
 	# Check Terminus version
-	# Terminus does not yet support PHP 8.0
+	# Terminus v2 is not compatible with PHP 8.0 or PHP 8.1
 	# See https://github.com/pantheon-systems/terminus/issues/2113
-	if [[ "${VERSION}" != "8.0" ]]; then
+	if [[ "${VERSION}" != "8.0" ]] && [[ "${VERSION}" != "8.1" ]]; then
 		run docker exec -u docker "$NAME" bash -lc 'set -x; terminus --version | grep "^Terminus ${TERMINUS_VERSION}$"'
 		[[ ${status} == 0 ]]
 		unset output
@@ -440,9 +440,10 @@ _healthcheck_wait ()
 @test "Check Pantheon integration" {
 	[[ $SKIP == 1 ]] && skip
 
-	# Terminus does not yet support PHP 8.0
+	# Terminus v2 is not compatible with PHP 8.0 or PHP 8.1
 	# See https://github.com/pantheon-systems/terminus/issues/2113
 	[[ "${VERSION}" == "8.0" ]] && skip
+	[[ "${VERSION}" == "8.1" ]] && skip
 
 	# Confirm secret is not empty
 	[[ "${SECRET_TERMINUS_TOKEN}" != "" ]]


### PR DESCRIPTION
- Using beta versions of Pecl MSSQL extensions for PHP 8.1
- Pecl gnupg not supported
- Pantheon Terminus CLI pinned at v2 for now
  - v2 is not compatible with PHP 8.x
  - v3 supports 7.4 and 8.0 only (does not support 7.3 or 8.1)
  - v3 changed the way `terminus auth:login` works in a way that breaks our login automation at startup
 
Closes #255 