### PR TITLE
Fix 'Configuration file loaded: none' in CLI

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -450,9 +450,7 @@ COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
 COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
-# PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
-# TODO: For now, will just hardcode a specific version available on https://github.com/php/php-src/
-ADD https://raw.githubusercontent.com/php/php-src/php-7.4.12/php.ini-development /usr/local/etc/php/php.ini
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY config/php/zz-php.ini /usr/local/etc/php/conf.d/zz-php.ini
 COPY config/php/xdebug.ini /opt/docker-php-ext-xdebug.ini
 COPY config/php/xhprof.ini /opt/docker-php-ext-xhprof.ini

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -448,9 +448,7 @@ COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
 COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
-# PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
-# TODO: For now, will just hardcode a specific version available on https://github.com/php/php-src/
-ADD https://raw.githubusercontent.com/php/php-src/PHP-8.0.5/php.ini-development /usr/local/etc/php/php.ini
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY config/php/zz-php.ini /usr/local/etc/php/conf.d/zz-php.ini
 COPY config/php/xdebug.ini /opt/docker-php-ext-xdebug.ini
 COPY config/php/xhprof.ini /opt/docker-php-ext-xhprof.ini

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -449,9 +449,7 @@ COPY startup.sh /opt/startup.sh
 COPY healthcheck.sh /opt/healthcheck.sh
 COPY ping-web.sh /opt/ping-web.sh
 # PHP default settings, global overrides and fpm overrides
-# PHP_VERSION is set upstream. The source code for the exact PHP version may not be available in Github
-# TODO: For now, will just hardcode a specific version available on https://github.com/php/php-src/
-ADD https://raw.githubusercontent.com/php/php-src/PHP-8.1.0/php.ini-development /usr/local/etc/php/php.ini
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 COPY config/php/zz-php.ini /usr/local/etc/php/conf.d/zz-php.ini
 COPY config/php/xdebug.ini /opt/docker-php-ext-xdebug.ini
 COPY config/php/xhprof.ini /opt/docker-php-ext-xhprof.ini


### PR DESCRIPTION
Currently, when running PHP commands in the CLI container using the a default image, then the php.ini file is not loaded:

```sh
$ fin exec php --ini
Configuration File (php.ini) Path: /usr/local/etc/php
Loaded Configuration File:         (none)
Scan for additional .ini files in: /usr/local/etc/php/conf.d
...
```

This is due to the fact that `php.ini` has not enough permissions:

```sh
$ fin exec ls -al /usr/local/etc/php
total 236
drwxr-xr-x 1 root root  4096 Jul 26 20:03 .
drwxr-xr-x 1 root root  4096 Jul 22 03:10 ..
drwxr-xr-x 1 root root  4096 Dec  7 08:19 conf.d
-rw------- 1 root root 72553 Jan  1  1970 php.ini
-rw-r--r-- 1 root root 72554 Jul 22 03:10 php.ini-development
-rw-r--r-- 1 root root 72584 Jul 22 03:10 php.ini-production
```

This is due to the fact that the php.ini is downloaded from a URL when building the image: https://github.com/docksal/service-cli/blob/da667acec01d6df7d2bd6b9ebda89c6e5f5145fc/7.4/Dockerfile#L455

And when using `ADD` with a URL, the permissions are always set to 600: https://docs.docker.com/engine/reference/builder/#add
> In the case where `<src>` is a remote file URL, the destination will have permissions of 600.

Since the PHP Docker image ships with a `php.ini-development` file, which is recommended to move to `php.ini`, it is better to do that instead of downloading it from the internet. This is documented here: https://hub.docker.com/_/php (section **Configuration**). Since these files have the right permissions. Using this file fixes the problem and it also resolves the problem that we use an hardcoded PHP version in the Dockerfile.