### PR TITLE
PHP 8.1 package updates

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -191,7 +191,7 @@ RUN set -xe; \
 	pecl update-channels; \
 	pecl install >/dev/null </dev/null \
 		apcu \
-		#gnupg \ # Not compatible with PHP 8.1
+		gnupg \
 		imagick \
 		memcached \
 		redis \
@@ -201,7 +201,7 @@ RUN set -xe; \
 	;\
 	docker-php-ext-enable \
 		apcu \
-		#gnupg \ # Not compatible with PHP 8.1
+		gnupg \
 		imagick \
 		memcached \
 		redis \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -231,10 +231,9 @@ RUN set -xe; \
 			msodbcsql17 \
 		;\
 		pecl update-channels; \
-		# TODO: Using beta. Switch to stable once PHP 8.1 support is finalized.
 		pecl install >/dev/null </dev/null \
-			pdo_sqlsrv-beta \
-			sqlsrv-beta \
+			pdo_sqlsrv \
+			sqlsrv \
 		;\
 		docker-php-ext-enable \
 			pdo_sqlsrv \

--- a/8.1/tests/php-modules.sh
+++ b/8.1/tests/php-modules.sh
@@ -18,6 +18,7 @@ filter
 ftp
 gd
 gettext
+gnupg
 hash
 iconv
 imagick
@@ -87,6 +88,7 @@ filter
 ftp
 gd
 gettext
+gnupg
 hash
 iconv
 imagick


### PR DESCRIPTION
- Re-enabled gnuphp for PHP 8.1 
  - Pecl `gnupg` added support for PHP 8.1 starting with v1.5.1
- Switched to stable sqlsrv (MSSQL) PHP extension for PHP 8.1 
  - Pecl `sqlsrv` fully supports for PHP 8.1 starting with v5.10.0