### PR TITLE
Update blackfire cli to v2.6.0

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -252,7 +252,7 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.6.0 \
-	BLACKFIRE_VERSION=1.49.3 \
+	BLACKFIRE_VERSION=2.6.0 \
 	PLATFORMSH_CLI_VERSION=3.76.2 \
 	ACQUIA_CLI_VERSION=1.22.0 \
 	TERMINUS_VERSION=3.0.6 \
@@ -272,7 +272,9 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI
-	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
+	# Find out the most recent version number:
+	# curl -X GET -Is https://blackfire.io/api/v1/releases/cli/linux/amd64 | grep location | awk '{print $2}'
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Acquia CLI

--- a/7.4/config/php/zz-php.ini
+++ b/7.4/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -252,7 +252,7 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.6.0 \
-	BLACKFIRE_VERSION=1.49.3 \
+	BLACKFIRE_VERSION=2.6.0 \
 	PLATFORMSH_CLI_VERSION=3.76.2 \
 	ACQUIA_CLI_VERSION=1.22.0 \
 	TERMINUS_VERSION=3.0.6 \
@@ -272,7 +272,9 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI
-	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
+	# Find out the most recent version number:
+	# curl -X GET -Is https://blackfire.io/api/v1/releases/cli/linux/amd64 | grep location | awk '{print $2}'
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Acquia CLI

--- a/8.0/config/php/zz-php.ini
+++ b/8.0/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -252,7 +252,7 @@ ENV COMPOSER_DEFAULT_VERSION=2 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.6.0 \
-	BLACKFIRE_VERSION=1.49.3 \
+	BLACKFIRE_VERSION=2.6.0 \
 	PLATFORMSH_CLI_VERSION=3.76.2 \
 	ACQUIA_CLI_VERSION=1.22.0 \
 	TERMINUS_VERSION=3.0.6 \
@@ -272,7 +272,9 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Blackfire CLI
-	curl -fsSL "https://packages.blackfire.io/binaries/blackfire-agent/${BLACKFIRE_VERSION}/blackfire-cli-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
+	# Find out the most recent version number:
+	# curl -X GET -Is https://blackfire.io/api/v1/releases/cli/linux/amd64 | grep location | awk '{print $2}'
+	curl -fsSL "https://packages.blackfire.io/binaries/blackfire/${BLACKFIRE_VERSION}/blackfire-linux_${TARGETARCH}" -o /usr/local/bin/blackfire; \
 	# Platform.sh CLI
 	curl -fsSL "https://github.com/platformsh/platformsh-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
 	# Acquia CLI

--- a/8.1/config/php/zz-php.ini
+++ b/8.1/config/php/zz-php.ini
@@ -15,4 +15,5 @@ sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
 [opcache]
 opcache.memory_consumption = 128
 [blackfire]
-blackfire.agent_socket = 'tcp://blackfire:8707'
+blackfire.agent_socket = 'tcp://blackfire:8307'
+blackfire.apm_enabled = 0

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -344,7 +344,7 @@ _healthcheck_wait ()
 	### Tests ###
 
 	# Check Blackfire CLI version
-	run docker exec -u docker "$NAME" bash -lc 'blackfire version | grep "^blackfire ${BLACKFIRE_VERSION} "'
+	run docker exec -u docker "$NAME" bash -lc 'blackfire version | grep "${BLACKFIRE_VERSION}"'
 	[[ ${status} == 0 ]]
 	unset output
 


### PR DESCRIPTION
- Updated blackfire cli to v2.6.0
- Updated blackfire port settings for v2
- Disabled Monitoring (APM) explicitly as Docksal is a dev platform
- Updated tests

Credit / closes: #250, closes #251.