### PR TITLE
Updated sendmail_path in php.ini

### DIFF
--- a/7.4/config/php/zz-php.ini
+++ b/7.4/config/php/zz-php.ini
@@ -9,7 +9,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --from=docker@cli'
 
 ; Extention settings
 [opcache]

--- a/8.0/config/php/zz-php.ini
+++ b/8.0/config/php/zz-php.ini
@@ -9,7 +9,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --from=docker@cli'
 
 ; Extention settings
 [opcache]

--- a/8.1/config/php/zz-php.ini
+++ b/8.1/config/php/zz-php.ini
@@ -9,7 +9,7 @@ display_startup_errors = On
 
 [mail]
 ; Enable Mailhog integration by default
-sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025'
+sendmail_path = '/usr/bin/msmtp -t --host=mail --port=1025 --from=docker@cli'
 
 ; Extention settings
 [opcache]

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -105,7 +105,7 @@ _healthcheck_wait ()
 	unset output
 
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 => /usr/bin/msmtp -t --host=mail --port=1025'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 --from=docker@cli'
 	unset output
 
 	run docker exec -u docker "$NAME" /var/www/docroot/php-fpm.sh nonsense.php
@@ -131,7 +131,7 @@ _healthcheck_wait ()
 	unset output
 
 	output=$(echo "$phpInfo" | grep "sendmail_path")
-	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 => /usr/bin/msmtp -t --host=mail --port=1025'
+	echo "$output" | grep '/usr/bin/msmtp -t --host=mail --port=1025 --from=docker@cli'
 	unset output
 
 	# Check PHP modules


### PR DESCRIPTION
This will make `mail()` work out of the box under every circumstance.

Setting the default `--from` option ensures PHP's built-in `mail()` function can be used without extra arguments (currently, you'd have to either set `-f <email>` or `--read-envelope-from`).

This also does not conflict with Drupal/etc., which may also try to pass `-f/--from` as an option in the 5th argument in `mail()`. See https://github.com/docksal/service-cli/issues/264#issuecomment-1046348914

Resolves: #264

Related to #117, which resulted in #142, which lead to #117 being reverted back in #149.
