### PR TITLE
Restore bundler

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -403,6 +403,16 @@ RUN set -e; \
 #	rvm cleanup all; \
 #	rvm gemset globalcache enable
 
+## Ruby bundler
+## Don't use -x here, as the output may be excessive
+RUN set -e; \
+	# Export ruby gem bin path
+	echo 'export PATH=$PATH:$(ruby -r rubygems -e "puts Gem.user_dir")/bin' >> $HOME/.profile; \
+	. $HOME/.profile; \
+	gem install --user-install bundler; \
+	# Have bundler install gems in the current directory (./.bundle) by default
+	echo -e "\n"'export BUNDLE_PATH=.bundle' >> $HOME/.profile
+
 # Python (installed as user) via pyenv
 # Note: Disabled. pyenv + its build dependecies bloat the image (~300MB).
 # Debian 10 ships with Python 3.7, so we'll stick with that by default.

--- a/7.4/tests/essential-binaries.sh
+++ b/7.4/tests/essential-binaries.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 binaries_amd64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -18,11 +19,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget
@@ -30,7 +36,8 @@ yq
 zip'
 
 binaries_arm64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -46,11 +53,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -403,6 +403,16 @@ RUN set -e; \
 #	rvm cleanup all; \
 #	rvm gemset globalcache enable
 
+## Ruby bundler
+## Don't use -x here, as the output may be excessive
+RUN set -e; \
+	# Export ruby gem bin path
+	echo 'export PATH=$PATH:$(ruby -r rubygems -e "puts Gem.user_dir")/bin' >> $HOME/.profile; \
+	. $HOME/.profile; \
+	gem install --user-install bundler; \
+	# Have bundler install gems in the current directory (./.bundle) by default
+	echo -e "\n"'export BUNDLE_PATH=.bundle' >> $HOME/.profile
+
 # Python (installed as user) via pyenv
 # Note: Disabled. pyenv + its build dependecies bloat the image (~300MB).
 # Debian 10 ships with Python 3.7, so we'll stick with that by default.

--- a/8.0/tests/essential-binaries.sh
+++ b/8.0/tests/essential-binaries.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 binaries_amd64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -18,11 +19,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget
@@ -30,7 +36,8 @@ yq
 zip'
 
 binaries_arm64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -46,11 +53,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -403,6 +403,16 @@ RUN set -e; \
 #	rvm cleanup all; \
 #	rvm gemset globalcache enable
 
+## Ruby bundler
+## Don't use -x here, as the output may be excessive
+RUN set -e; \
+	# Export ruby gem bin path
+	echo 'export PATH=$PATH:$(ruby -r rubygems -e "puts Gem.user_dir")/bin' >> $HOME/.profile; \
+	. $HOME/.profile; \
+	gem install --user-install bundler; \
+	# Have bundler install gems in the current directory (./.bundle) by default
+	echo -e "\n"'export BUNDLE_PATH=.bundle' >> $HOME/.profile
+
 # Python (installed as user) via pyenv
 # Note: Disabled. pyenv + its build dependecies bloat the image (~300MB).
 # Debian 10 ships with Python 3.7, so we'll stick with that by default.

--- a/8.1/tests/essential-binaries.sh
+++ b/8.1/tests/essential-binaries.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 binaries_amd64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -18,11 +19,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget
@@ -30,7 +36,8 @@ yq
 zip'
 
 binaries_arm64=\
-'cat
+'bundler
+cat
 convert
 curl
 dig
@@ -46,11 +53,16 @@ mc
 more
 mysql
 nano
+node
+nvm
 nslookup
+php
 ping
 psql
 pv
+python3
 rsync
+ruby
 sudo
 unzip
 wget


### PR DESCRIPTION
- Added `bundler` back 
  - `bundler` was unintentionally dropped in v3.0.0 along with `rvm`
- Updated the lists of essential binaries 
  - Added: `bundler`, `node`, `nvm`, `php`, `python3`, `ruby`

Fixes #272 