### PR TITLE
Added python3-pip

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -293,13 +293,12 @@ RUN set -xe; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus yq);
 
-# Install Python3 from Debian repos
-# This adds about 30MB to uncompressed image size.
-# TODO: some other dependency in this image installs python2. Which one?
+# Install Python 3 + pip from Debian repos
 RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		python3 \
+		python3-pip \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/7.4/tests/essential-binaries.sh
+++ b/7.4/tests/essential-binaries.sh
@@ -24,6 +24,7 @@ nvm
 nslookup
 php
 ping
+pip
 psql
 pv
 python3

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -293,13 +293,12 @@ RUN set -xe; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus yq);
 
-# Install Python3 from Debian repos
-# This adds about 30MB to uncompressed image size.
-# TODO: some other dependency in this image installs python2. Which one?
+# Install Python 3 + pip from Debian repos
 RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		python3 \
+		python3-pip \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/8.0/tests/essential-binaries.sh
+++ b/8.0/tests/essential-binaries.sh
@@ -24,6 +24,7 @@ nvm
 nslookup
 php
 ping
+pip
 psql
 pv
 python3

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -293,13 +293,12 @@ RUN set -xe; \
 	# Make all downloaded binaries executable in one shot
 	(cd /usr/local/bin && chmod +x composer1 composer2 drush8 drush drupal wp blackfire platform acli terminus yq);
 
-# Install Python3 from Debian repos
-# This adds about 30MB to uncompressed image size.
-# TODO: some other dependency in this image installs python2. Which one?
+# Install Python 3 + pip from Debian repos
 RUN set -xe; \
 	apt-get update >/dev/null; \
 	apt-get -y --no-install-recommends install >/dev/null \
 		python3 \
+		python3-pip \
 	;\
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*

--- a/8.1/tests/essential-binaries.sh
+++ b/8.1/tests/essential-binaries.sh
@@ -24,6 +24,7 @@ nvm
 nslookup
 php
 ping
+pip
 psql
 pv
 python3


### PR DESCRIPTION
`pip` was lost unintentionally in the v3.0 release. Added a test to check for the `pip` binary.

Fixes #276 