### PR TITLE
Release 3.3.0

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
     name: "Build: ${{ matrix.version }}/${{ matrix.arch }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
@@ -64,7 +64,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Environment variables
         run: |
@@ -92,14 +92,14 @@ jobs:
           docker info
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         # Build and cache image in the registry
         name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ env.BUILD_DIR }}
           file: ${{ env.BUILD_DIR }}/Dockerfile
@@ -113,7 +113,7 @@ jobs:
 
   test:
     name: "Test: ${{ matrix.version }}/${{ matrix.arch }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
 
     strategy:
@@ -158,7 +158,7 @@ jobs:
           bats-version: '1.3.0'
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Environment variables
         run: |
@@ -201,14 +201,14 @@ jobs:
       # Dynamic variable names cannot be used when mapping step outputs to job outputs.
       # Step outputs cannot be accessed directly from other jobs. Dead end.
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: ${{ github.workspace }}/test-results-*.txt
 
   push:
     name: "Push: ${{ matrix.version }}/multi"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Wait for test to either succeed or fail
     needs: test
@@ -228,7 +228,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Environment variables
         run: |
@@ -239,7 +239,7 @@ jobs:
       -
         # Login to Docker Hub
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-bullseye as cli
+FROM php:7.4.33-fpm-bullseye as cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
@@ -84,8 +84,13 @@ RUN set -xe; \
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-ENV GOSU_VERSION=1.12 \
-	GOMPLATE_VERSION=3.9.0
+# gosu v1.14+ discorages using it as a non-root user (https://github.com/tianon/gosu/issues/11), which we rely on here.
+# See https://github.com/tianon/gosu/pull/89/commits/8afd3dec5fb4fe0356e4fb5d358fe235f7311181
+# We'll stick with v1.13 for the time being.
+# TODO: Replace gosu with sudo/su in startup.sh
+ENV \
+	GOSU_VERSION=1.13 \
+	GOMPLATE_VERSION=3.11.3
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -195,7 +200,8 @@ RUN set -xe; \
 		memcached \
 		redis \
 		ssh2-beta \
-		xdebug \
+		# xdebug v3.1.6 is the last version to support PHP 7.4
+		xdebug-3.1.6 \
 		xhprof \
 	;\
 	docker-php-ext-enable \
@@ -245,19 +251,21 @@ RUN set -xe; \
 	fi
 
 # PHP tools (installed globally)
-ENV COMPOSER_DEFAULT_VERSION=2 \
+ENV \
+	COMPOSER_DEFAULT_VERSION=2 \
 	COMPOSER_VERSION=1.10.26 \
-	COMPOSER2_VERSION=2.3.10 \
+	COMPOSER2_VERSION=2.5.1 \
 	DRUSH_VERSION=8.4.11 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
-	WPCLI_VERSION=2.6.0 \
+	WPCLI_VERSION=2.7.1 \
 	BLACKFIRE_VERSION=2.10.0 \
-	PLATFORMSH_CLI_VERSION=3.80.3 \
+	PLATFORMSH_CLI_VERSION=4.0.2 \
+	# acquia/cli v1.30.1 is the last version to support PHP 7.4
 	ACQUIA_CLI_VERSION=1.30.1 \
-	TERMINUS_VERSION=3.0.7 \
+	TERMINUS_VERSION=3.1.2 \
 	JQ_VERSION=1.6 \
-	YQ_VERSION=4.26.1
+	YQ_VERSION=4.30.8
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -344,9 +352,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.39.1 \
-	NODE_VERSION=16.16.0 \
-	YARN_VERSION=1.22.17
+	NVM_VERSION=0.39.3 \
+	NODE_VERSION=18.13.0 \
+	YARN_VERSION=1.22.19
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -510,9 +518,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.5.1 \
-	VSCODE_GITLENS_VERSION=12.1.2 \
-	VSCODE_XDEBUG_VERSION=1.27.0 \
+	CODE_SERVER_VERSION=4.9.1 \
+	VSCODE_GITLENS_VERSION=13.2.0 \
+	VSCODE_XDEBUG_VERSION=1.30.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-bullseye as cli
+FROM php:8.0.27-fpm-bullseye as cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
@@ -84,8 +84,13 @@ RUN set -xe; \
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-ENV GOSU_VERSION=1.12 \
-	GOMPLATE_VERSION=3.9.0
+# gosu v1.14+ discorages using it as a non-root user (https://github.com/tianon/gosu/issues/11), which we rely on here.
+# See https://github.com/tianon/gosu/pull/89/commits/8afd3dec5fb4fe0356e4fb5d358fe235f7311181
+# We'll stick with v1.13 for the time being.
+# TODO: Replace gosu with sudo/su in startup.sh
+ENV \
+	GOSU_VERSION=1.13 \
+	GOMPLATE_VERSION=3.11.3
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -245,19 +250,20 @@ RUN set -xe; \
 	fi
 
 # PHP tools (installed globally)
-ENV COMPOSER_DEFAULT_VERSION=2 \
+ENV \
+	COMPOSER_DEFAULT_VERSION=2 \
 	COMPOSER_VERSION=1.10.26 \
-	COMPOSER2_VERSION=2.3.10 \
+	COMPOSER2_VERSION=2.5.1 \
 	DRUSH_VERSION=8.4.11 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
-	WPCLI_VERSION=2.6.0 \
+	WPCLI_VERSION=2.7.1 \
 	BLACKFIRE_VERSION=2.10.0 \
-	PLATFORMSH_CLI_VERSION=3.80.3 \
-	ACQUIA_CLI_VERSION=2.1.0 \
-	TERMINUS_VERSION=3.0.7 \
+	PLATFORMSH_CLI_VERSION=4.0.2 \
+	ACQUIA_CLI_VERSION=2.7.0 \
+	TERMINUS_VERSION=3.1.2 \
 	JQ_VERSION=1.6 \
-	YQ_VERSION=4.26.1
+	YQ_VERSION=4.30.8
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -344,9 +350,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.39.1 \
-	NODE_VERSION=16.16.0 \
-	YARN_VERSION=1.22.17
+	NVM_VERSION=0.39.3 \
+	NODE_VERSION=18.13.0 \
+	YARN_VERSION=1.22.19
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -510,9 +516,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.5.1 \
-	VSCODE_GITLENS_VERSION=12.1.2 \
-	VSCODE_XDEBUG_VERSION=1.27.0 \
+	CODE_SERVER_VERSION=4.9.1 \
+	VSCODE_GITLENS_VERSION=13.2.0 \
+	VSCODE_XDEBUG_VERSION=1.30.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye as cli
+FROM php:8.1.14-fpm-bullseye as cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
@@ -84,8 +84,13 @@ RUN set -xe; \
 	usermod -a -G sudo docker; \
 	echo 'docker ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-ENV GOSU_VERSION=1.12 \
-	GOMPLATE_VERSION=3.9.0
+# gosu v1.14+ discorages using it as a non-root user (https://github.com/tianon/gosu/issues/11), which we rely on here.
+# See https://github.com/tianon/gosu/pull/89/commits/8afd3dec5fb4fe0356e4fb5d358fe235f7311181
+# We'll stick with v1.13 for the time being.
+# TODO: Replace gosu with sudo/su in startup.sh
+ENV \
+	GOSU_VERSION=1.13 \
+	GOMPLATE_VERSION=3.11.3
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -245,19 +250,20 @@ RUN set -xe; \
 	fi
 
 # PHP tools (installed globally)
-ENV COMPOSER_DEFAULT_VERSION=2 \
+ENV \
+	COMPOSER_DEFAULT_VERSION=2 \
 	COMPOSER_VERSION=1.10.26 \
-	COMPOSER2_VERSION=2.3.10 \
+	COMPOSER2_VERSION=2.5.1 \
 	DRUSH_VERSION=8.4.11 \
 	DRUSH_LAUNCHER_VERSION=0.10.1 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
-	WPCLI_VERSION=2.6.0 \
+	WPCLI_VERSION=2.7.1 \
 	BLACKFIRE_VERSION=2.10.0 \
-	PLATFORMSH_CLI_VERSION=3.80.3 \
-	ACQUIA_CLI_VERSION=2.1.0 \
-	TERMINUS_VERSION=3.0.7 \
+	PLATFORMSH_CLI_VERSION=4.0.2 \
+	ACQUIA_CLI_VERSION=2.7.0 \
+	TERMINUS_VERSION=3.1.2 \
 	JQ_VERSION=1.6 \
-	YQ_VERSION=4.26.1
+	YQ_VERSION=4.30.8
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -344,9 +350,9 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.39.1 \
-	NODE_VERSION=16.16.0 \
-	YARN_VERSION=1.22.17
+	NVM_VERSION=0.39.3 \
+	NODE_VERSION=18.13.0 \
+	YARN_VERSION=1.22.19
 # Don't use -x here, as the output may be excessive
 RUN set -e; \
 	# NVM and a defaut Node.js version
@@ -510,9 +516,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.5.1 \
-	VSCODE_GITLENS_VERSION=12.1.2 \
-	VSCODE_XDEBUG_VERSION=1.27.0 \
+	CODE_SERVER_VERSION=4.9.1 \
+	VSCODE_GITLENS_VERSION=13.2.0 \
+	VSCODE_XDEBUG_VERSION=1.30.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -505,8 +505,10 @@ _healthcheck_wait ()
 
 	### Tests ###
 
-	# Give cron 60s to invoke the scheduled test job
-	sleep 60
+	# Wait for cron to run.
+	# This test keeps failing randomly...
+	# Worst case, the wait would need to be 120s (double the 60s minimal interval possible with cron).
+	sleep 90
 	# Confirm cron has run and file contents has changed
 	run docker exec -u docker "$NAME" bash -lc 'tail -1 /tmp/date.txt'
 	[[ "${output}" =~ "The current date is " ]]


### PR DESCRIPTION
- Version bumps
  - PHP 7.4.33 / PHP 8.0.27 / PHP 8.1.14
  - tianon/gosu 1.13
  - hairyhenderson/gomplate 3.11.3
  - composer/composer 2.5.1
  - wp-cli/wp-cli 2.7.1
  - platformsh/legacy-cli 4.0.2
  - acquia/cli 2.7.0 (1.30.1 for PHP 7.4)
  - pantheon-systems/terminus 3.1.2
  - mikefarah/yq 4.30.8
  - nvm-sh/nvm 0.39.3
  - node.js 18.13.0 LTS
  - yarnpkg/yarn 1.22.19
  - coder/code-server 4.9.1
  - gitkraken/vscode-gitlens 13.2.0
  - xdebug/vscode-php-debug 1.30.0
- Pinning xdebug at 3.1.6 for PHP 7.4
- Increased the timeout in the cronjob test
- Updated versions of GitHub Actions dependencies