### PR TITLE
SQLite, Platform.sh CLI, misc

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -161,8 +161,7 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.11.0 \
-	# platformsh/legacy-cli
-	PLATFORMSH_CLI_VERSION=4.23.0 \
+	PLATFORMSH_CLI_VERSION=5.0.23 \
 	ACQUIA_CLI_VERSION=2.41.1 \
 	TERMINUS_VERSION=3.6.2 \
 	JQ_VERSION=1.7.1 \
@@ -179,7 +178,8 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Platform.sh CLI
-	curl -fsSL "https://github.com/platformsh/legacy-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/cli/releases/download/${PLATFORMSH_CLI_VERSION}/platform_${PLATFORMSH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" -o /tmp/platform.tar.gz; \
+	tar -xzf /tmp/platform.tar.gz -C /tmp && mv /tmp/platform /usr/local/bin/platform; rm -rf /tmp/*; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -212,6 +212,16 @@ RUN set -xe; \
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Install a newer SQLite version from Debian Trixie (testing) repo
+# Debian Bookworm (main) ships with sqlite v3.40. Drupal 11 requires SQLite v3.45+.
+# @see https://www.drupal.org/project/drupal/issues/3346338
+RUN set -xe; \
+	echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+	apt-get update >/dev/null; \
+	apt-get install -y -t testing sqlite3;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*; rm -f /etc/apt/sources.list.d/testing.list
+
 # All further RUN commands will run as the "docker" user
 USER docker
 SHELL ["/bin/bash", "-c"]

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -25,8 +25,10 @@ RUN set -xe; \
 
 # Set en_US.UTF-8 as the default locale
 RUN set -xe; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LC_ALL en_US.utf8
+	echo "en_US.UTF-8 UTF-8" | tee -a /etc/locale.gen; \
+	locale-gen en_US.UTF-8; \
+	update-locale LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Additional packages
 RUN set -xe; \
@@ -101,7 +103,7 @@ RUN set -xe; \
 	# SSH login fix. Otherwise user is kicked off after login
 	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
 	echo "export VISIBLE=now" >> /etc/profile
-ENV NOTVISIBLE "in users profile"
+ENV NOTVISIBLE="in users profile"
 
 # PHP
 RUN set -xe; \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -213,6 +213,16 @@ RUN set -xe; \
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Install a newer SQLite version from Debian Trixie (testing) repo
+# Debian Bookworm (main) ships with sqlite v3.40. Drupal 11 requires SQLite v3.45+.
+# @see https://www.drupal.org/project/drupal/issues/3346338
+RUN set -xe; \
+	echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+	apt-get update >/dev/null; \
+	apt-get install -y -t testing sqlite3;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*; rm -f /etc/apt/sources.list.d/testing.list
+
 # All further RUN commands will run as the "docker" user
 USER docker
 SHELL ["/bin/bash", "-c"]

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -162,8 +162,7 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.11.0 \
-	# platformsh/legacy-cli
-	PLATFORMSH_CLI_VERSION=4.23.0 \
+	PLATFORMSH_CLI_VERSION=5.0.23 \
 	ACQUIA_CLI_VERSION=2.41.1 \
 	TERMINUS_VERSION=3.6.2 \
 	JQ_VERSION=1.7.1 \
@@ -180,7 +179,8 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Platform.sh CLI
-	curl -fsSL "https://github.com/platformsh/legacy-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/cli/releases/download/${PLATFORMSH_CLI_VERSION}/platform_${PLATFORMSH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" -o /tmp/platform.tar.gz; \
+	tar -xzf /tmp/platform.tar.gz -C /tmp && mv /tmp/platform /usr/local/bin/platform; rm -rf /tmp/*; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -25,8 +25,10 @@ RUN set -xe; \
 
 # Set en_US.UTF-8 as the default locale
 RUN set -xe; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LC_ALL en_US.utf8
+	echo "en_US.UTF-8 UTF-8" | tee -a /etc/locale.gen; \
+	locale-gen en_US.UTF-8; \
+	update-locale LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Additional packages
 RUN set -xe; \
@@ -101,7 +103,7 @@ RUN set -xe; \
 	# SSH login fix. Otherwise user is kicked off after login
 	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
 	echo "export VISIBLE=now" >> /etc/profile
-ENV NOTVISIBLE "in users profile"
+ENV NOTVISIBLE="in users profile"
 
 # PHP
 RUN set -xe; \

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -213,14 +213,15 @@ RUN set -xe; \
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
-# Upgrade SQLite for Drupal 11 testing.
+# Install a newer SQLite version from Debian Trixie (testing) repo
+# Debian Bookworm (main) ships with sqlite v3.40. Drupal 11 requires SQLite v3.45+.
 # @see https://www.drupal.org/project/drupal/issues/3346338
 RUN set -xe; \
-  echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
-  apt-get update >/dev/null; \
-  apt-get install -y -t testing sqlite3;\
-  # Cleanup
-  apt-get clean; rm -rf /var/lib/apt/lists/*
+	echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+	apt-get update >/dev/null; \
+	apt-get install -y -t testing sqlite3;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*; rm -f /etc/apt/sources.list.d/testing.list
 
 # All further RUN commands will run as the "docker" user
 USER docker

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -213,6 +213,15 @@ RUN set -xe; \
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Upgrade SQLite for Drupal 11 testing.
+# @see https://www.drupal.org/project/drupal/issues/3346338
+RUN set -xe; \
+  echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+  apt-get update >/dev/null; \
+  apt-get install -y -t testing sqlite3;\
+  # Cleanup
+  apt-get clean; rm -rf /var/lib/apt/lists/*
+
 # All further RUN commands will run as the "docker" user
 USER docker
 SHELL ["/bin/bash", "-c"]

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -162,8 +162,7 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.11.0 \
-	# platformsh/legacy-cli
-	PLATFORMSH_CLI_VERSION=4.23.0 \
+	PLATFORMSH_CLI_VERSION=5.0.23 \
 	ACQUIA_CLI_VERSION=2.41.1 \
 	TERMINUS_VERSION=3.6.2 \
 	JQ_VERSION=1.7.1 \
@@ -180,7 +179,8 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Platform.sh CLI
-	curl -fsSL "https://github.com/platformsh/legacy-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/cli/releases/download/${PLATFORMSH_CLI_VERSION}/platform_${PLATFORMSH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" -o /tmp/platform.tar.gz; \
+	tar -xzf /tmp/platform.tar.gz -C /tmp && mv /tmp/platform /usr/local/bin/platform; rm -rf /tmp/*; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -25,8 +25,10 @@ RUN set -xe; \
 
 # Set en_US.UTF-8 as the default locale
 RUN set -xe; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LC_ALL en_US.utf8
+	echo "en_US.UTF-8 UTF-8" | tee -a /etc/locale.gen; \
+	locale-gen en_US.UTF-8; \
+	update-locale LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Additional packages
 RUN set -xe; \
@@ -101,7 +103,7 @@ RUN set -xe; \
 	# SSH login fix. Otherwise user is kicked off after login
 	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
 	echo "export VISIBLE=now" >> /etc/profile
-ENV NOTVISIBLE "in users profile"
+ENV NOTVISIBLE="in users profile"
 
 # PHP
 RUN set -xe; \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -162,8 +162,7 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.11.0 \
-	# platformsh/legacy-cli
-	PLATFORMSH_CLI_VERSION=4.23.0 \
+	PLATFORMSH_CLI_VERSION=5.0.23 \
 	ACQUIA_CLI_VERSION=2.41.1 \
 	# pantheon-systems/terminus added PHP 8.4 support in 4.0.0-alpha1
 	TERMINUS_VERSION=4.0.0-alpha2 \
@@ -181,7 +180,8 @@ RUN set -xe; \
 	# Wordpress CLI
 	curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${WPCLI_VERSION}/wp-cli-${WPCLI_VERSION}.phar" -o /usr/local/bin/wp; \
 	# Platform.sh CLI
-	curl -fsSL "https://github.com/platformsh/legacy-cli/releases/download/v${PLATFORMSH_CLI_VERSION}/platform.phar" -o /usr/local/bin/platform; \
+	curl -fsSL "https://github.com/platformsh/cli/releases/download/${PLATFORMSH_CLI_VERSION}/platform_${PLATFORMSH_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" -o /tmp/platform.tar.gz; \
+	tar -xzf /tmp/platform.tar.gz -C /tmp && mv /tmp/platform /usr/local/bin/platform; rm -rf /tmp/*; \
 	# Acquia CLI
 	curl -fsSL "https://github.com/acquia/cli/releases/download/${ACQUIA_CLI_VERSION}/acli.phar" -o /usr/local/bin/acli; \
 	# Pantheon Terminus

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -25,8 +25,10 @@ RUN set -xe; \
 
 # Set en_US.UTF-8 as the default locale
 RUN set -xe; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LC_ALL en_US.utf8
+	echo "en_US.UTF-8 UTF-8" | tee -a /etc/locale.gen; \
+	locale-gen en_US.UTF-8; \
+	update-locale LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Additional packages
 RUN set -xe; \
@@ -101,7 +103,7 @@ RUN set -xe; \
 	# SSH login fix. Otherwise user is kicked off after login
 	sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd; \
 	echo "export VISIBLE=now" >> /etc/profile
-ENV NOTVISIBLE "in users profile"
+ENV NOTVISIBLE="in users profile"
 
 # PHP
 RUN set -xe; \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -214,6 +214,16 @@ RUN set -xe; \
 	# Cleanup
 	apt-get clean; rm -rf /var/lib/apt/lists/*
 
+# Install a newer SQLite version from Debian Trixie (testing) repo
+# Debian Bookworm (main) ships with sqlite v3.40. Drupal 11 requires SQLite v3.45+.
+# @see https://www.drupal.org/project/drupal/issues/3346338
+RUN set -xe; \
+	echo "deb https://deb.debian.org/debian testing main" | tee /etc/apt/sources.list.d/testing.list; \
+	apt-get update >/dev/null; \
+	apt-get install -y -t testing sqlite3;\
+	# Cleanup
+	apt-get clean; rm -rf /var/lib/apt/lists/*; rm -f /etc/apt/sources.list.d/testing.list
+
 # All further RUN commands will run as the "docker" user
 USER docker
 SHELL ["/bin/bash", "-c"]

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -223,7 +223,7 @@ _healthcheck_wait ()
 	unset output
 
 	# Check Platform CLI version
-	run docker exec -u docker "$NAME" bash -lc 'set -x; platform --version | grep "Platform.sh CLI (legacy) ${PLATFORMSH_CLI_VERSION}"'
+	run docker exec -u docker "$NAME" bash -lc 'set -x; platform --version | grep "Platform.sh CLI ${PLATFORMSH_CLI_VERSION}"'
 	[[ ${status} == 0 ]]
 	unset output
 


### PR DESCRIPTION
- Install SQLite from Debian Trixie (testing) repo 
  - SQLite v3.45+ required for Drupal 11
- Platform.sh CLI v5.0.23 
  - Replaced `platformsh/legacy-cli` with `platformsh/cli`
- Locale setup fix

Resolves #326. Closes #327