### PR TITLE
Release 3.10.0

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -161,12 +161,12 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.0.23 \
+	PLATFORMSH_CLI_VERSION=5.6.0 \
 	ACQUIA_CLI_VERSION=2.49.0 \
 	# Pin Terminus 3.6.2 for PHP 8.1
 	TERMINUS_VERSION=3.6.2 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.47.2
+	YQ_VERSION=4.48.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -253,8 +253,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.40.2 \
-	NODE_VERSION=22.14.0 \
+	NVM_VERSION=0.40.3 \
+	NODE_VERSION=22.20.0 \
 	# Yarn (Classic v1)
 	# https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
@@ -345,9 +345,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.99.3 \
-	VSCODE_GITLENS_VERSION=17.0.3 \
-	VSCODE_XDEBUG_VERSION=1.36.0 \
+	CODE_SERVER_VERSION=4.104.3 \
+	VSCODE_GITLENS_VERSION=17.6.1 \
+	VSCODE_XDEBUG_VERSION=1.37.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -162,11 +162,11 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.0.23 \
+	PLATFORMSH_CLI_VERSION=5.6.0 \
 	ACQUIA_CLI_VERSION=2.49.0 \
 	TERMINUS_VERSION=4.1.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.47.2
+	YQ_VERSION=4.48.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -253,8 +253,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.40.2 \
-	NODE_VERSION=22.14.0 \
+	NVM_VERSION=0.40.3 \
+	NODE_VERSION=22.20.0 \
 	# Yarn (Classic v1)
 	# https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
@@ -345,9 +345,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.99.3 \
-	VSCODE_GITLENS_VERSION=17.0.3 \
-	VSCODE_XDEBUG_VERSION=1.36.0 \
+	CODE_SERVER_VERSION=4.104.3 \
+	VSCODE_GITLENS_VERSION=17.6.1 \
+	VSCODE_XDEBUG_VERSION=1.37.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -162,11 +162,11 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.0.23 \
+	PLATFORMSH_CLI_VERSION=5.6.0 \
 	ACQUIA_CLI_VERSION=2.49.0 \
 	TERMINUS_VERSION=4.1.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.47.2
+	YQ_VERSION=4.48.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -253,8 +253,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.40.2 \
-	NODE_VERSION=22.14.0 \
+	NVM_VERSION=0.40.3 \
+	NODE_VERSION=22.20.0 \
 	# Yarn (Classic v1)
 	# https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
@@ -345,9 +345,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.99.3 \
-	VSCODE_GITLENS_VERSION=17.0.3 \
-	VSCODE_XDEBUG_VERSION=1.36.0 \
+	CODE_SERVER_VERSION=4.104.3 \
+	VSCODE_GITLENS_VERSION=17.6.1 \
+	VSCODE_XDEBUG_VERSION=1.37.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -162,11 +162,11 @@ ENV \
 	DRUSH_VERSION=8.4.12 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.0.23 \
+	PLATFORMSH_CLI_VERSION=5.6.0 \
 	ACQUIA_CLI_VERSION=2.49.0 \
 	TERMINUS_VERSION=4.1.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.47.2
+	YQ_VERSION=4.48.1
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -253,8 +253,8 @@ $HOME/.composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCompatibil
 
 # Node.js (installed as user)
 ENV \
-	NVM_VERSION=0.40.2 \
-	NODE_VERSION=22.14.0 \
+	NVM_VERSION=0.40.3 \
+	NODE_VERSION=22.20.0 \
 	# Yarn (Classic v1)
 	# https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
@@ -345,9 +345,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.99.3 \
-	VSCODE_GITLENS_VERSION=17.0.3 \
-	VSCODE_XDEBUG_VERSION=1.36.0 \
+	CODE_SERVER_VERSION=4.104.3 \
+	VSCODE_GITLENS_VERSION=17.6.1 \
+	VSCODE_XDEBUG_VERSION=1.37.0 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cli
 ## NodeJS
 
 - nvm
-- node v22.14.0 LTS (following NodeJS LTS release cycle)
+- node v22.20.0 LTS (following NodeJS LTS release cycle)
 - yarn (classic v1)
 
 NodeJS is installed via `nvm` in the `docker` user's profile inside the image (`/home/docker/.nvm`).

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,7 +76,7 @@ _healthcheck_wait ()
 
 	# Check all binaries in a single shot
 	run make exec -e CMD="type $(echo ${binaries} | xargs)"
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	### Cleanup ###
@@ -192,44 +192,43 @@ _healthcheck_wait ()
 	### Tests ###
 
 	# Check Composer v1 version (legacy)
-	run docker exec -u docker "$NAME" bash -lc 'set -x; composer1 --version | grep "^Composer version ${COMPOSER_VERSION} "'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; composer1 --version | grep "${COMPOSER_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Composer v2 version (default)
-	run docker exec -u docker "$NAME" bash -lc 'set -x; composer --version | grep "^Composer version ${COMPOSER2_VERSION} "'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; composer --version | grep "${COMPOSER2_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Drush 8 version (legacy)
-	run docker exec -u docker "$NAME" bash -lc 'set -x; drush8 --version | grep "^ Drush Version   :  ${DRUSH_VERSION} $"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; drush8 --version | grep "${DRUSH_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Drupal Console version
-	run docker exec -u docker "$NAME" bash -lc 'set -x; drupal --version | grep "^Drupal Console Launcher ${DRUPAL_CONSOLE_LAUNCHER_VERSION}$"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; drupal --version | grep "${DRUPAL_CONSOLE_LAUNCHER_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Wordpress CLI version
-	run docker exec -u docker "$NAME" bash -lc 'set -x; wp --version | grep "^WP-CLI ${WPCLI_VERSION}$"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; wp --version | grep "${WPCLI_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Terminus version
-	# --no-ansi is used to strip color codes from the output, otherwise the grep will fail
-	run docker exec -u docker "$NAME" bash -lc 'set -x; terminus --no-ansi --version | grep "^Terminus ${TERMINUS_VERSION}$"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; terminus --version | grep "${TERMINUS_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Platform CLI version
-	run docker exec -u docker "$NAME" bash -lc 'set -x; platform --version | grep "Platform.sh CLI ${PLATFORMSH_CLI_VERSION}"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; platform --version | grep "${PLATFORMSH_CLI_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check Acquia CLI version
-	run docker exec -u docker "$NAME" bash -lc 'set -x; acli --version | grep "^Acquia CLI ${ACQUIA_CLI_VERSION}"'
-	[[ ${status} == 0 ]]
+	run docker exec -u docker "$NAME" bash -lc 'set -x; acli --version | grep "${ACQUIA_CLI_VERSION}"'
+	[ "$status" -eq 0 ]
 	unset output
 
 	### Cleanup ###
@@ -249,27 +248,27 @@ _healthcheck_wait ()
 
 	# nvm
 	run docker exec -u docker "$NAME" bash -lc 'nvm --version | grep "${NVM_VERSION}"'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	# nodejs
 	run docker exec -u docker "$NAME" bash -lc 'node --version | grep "${NODE_VERSION}"'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	# yarn
 	run docker exec -u docker "$NAME" bash -lc 'yarn --version | grep "${YARN_VERSION}"'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Stock Ruby version in Debian 12 is 3.1.x
 	run docker exec -u docker "$NAME" bash -lc 'ruby --version | grep "ruby 3.1"'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Stock Python version in Debian 12 is 3.11.x
 	run docker exec -u docker "$NAME" bash -lc 'python3 --version 2>&1 | grep "Python 3.11"'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	# Check msmtp
@@ -304,7 +303,7 @@ _healthcheck_wait ()
 	unset output
 	# TODO: figure out how to properly use 'make exec' here (escape quotes)
 	run docker exec -u docker "${NAME}" bash -lc 'echo "${SECRET_SSH_PRIVATE_KEY}" | base64 -d | diff ${HOME}/.ssh/id_rsa -'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	unset output
 
 	### Cleanup ###
@@ -327,7 +326,7 @@ _healthcheck_wait ()
 	sleep 2
 
 	run docker exec -u docker "${NAME}" cat /tmp/test-startup.txt
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	[[ "${output}" =~ "I ran properly" ]]
 
 	### Cleanup ###
@@ -360,7 +359,7 @@ _healthcheck_wait ()
 
 	# Confirm authentication works
 	run docker exec -u docker "${NAME}" bash -lc 'platform auth:info --no-interaction'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	[[ ! "${output}" =~ "Invalid API token" ]]
 	[[ "${output}" =~ "developer@docksal.io" ]]
 	unset output
@@ -404,7 +403,7 @@ _healthcheck_wait ()
 
 	# Confirm we are logged in with the expected user
 	run docker exec -u docker "${NAME}" bash -lc 'terminus site:list'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	[[ ! "${output}" =~ "You are not logged in." ]]
 	unset output
 
@@ -412,7 +411,7 @@ _healthcheck_wait ()
 	# terminus auth:whoami is finicky/buggy and needs another command to run to create a session first.
 	# See https://github.com/docksal/service-cli/issues/258
 	run docker exec -u docker "${NAME}" bash -lc 'terminus auth:whoami'
-	[[ ${status} == 0 ]]
+	[ "$status" -eq 0 ]
 	[[ ! "${output}" =~ "You are not logged in." ]]
 	[[ "${output}" =~ "developer@docksal.io" ]]
 	unset output


### PR DESCRIPTION
- PHP updates
  - PHP 8.1.33
  - PHP 8.2.29
  - PHP 8.3.26
  - PHP 8.4.13
- Various package updates
  - Composer 2.8.12
  - Acquia CLI 2.49.0
  - Platform.sh CLI 
  - Terminus 4.1.0 (pinned at 3.6.2 for PHP 8.1)
  - wp-cli 2.11.0
  - jq 1.8.1
  - yq 4.47.2
  - Node.js 22.20.0 LTS
  - nvm 0.40.3
- VS Code Server updates
  - VS Code Server 4.104.3
  - VS Code GitLens 17.6.1
  - VS Code Xdebug 1.37.0