### PR TITLE
Version Updates

### DIFF
--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.2.30-fpm-trixie AS cli
+FROM php:8.2.31-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.3.30-fpm-trixie AS cli
+FROM php:8.3.31-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.4.17-fpm-trixie AS cli
+FROM php:8.4.21-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -148,9 +148,9 @@ RUN set -xe; \
 		ssh2 \
 		xdebug \
 		xhprof \
-		# MSSQL PHP client - not available yet for PHP 8.5 via docker-php-extension-installer
-		# pdo_sqlsrv \
-		# sqlsrv \
+		# MSSQL PHP client
+		pdo_sqlsrv \
+		sqlsrv \
 	;\
 	# Disable xdebug and xhprof by default to avoid performance impact
 	# They can be enabled via environment variables at runtime (XDEBUG_ENABLED=1 and XHPROF_ENABLED=1)

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -161,20 +161,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	# Terminus does not yet support PHP 8.5 officially.
-	# This env var allows running it on newer PHP versions regardless.
-	# https://github.com/pantheon-systems/terminus/issues/2751
-	TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP=1 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -254,7 +250,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -343,9 +339,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.5.2-fpm-trixie AS cli
+FROM php:8.5.6-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.5/tests/php-modules.sh
+++ b/8.5/tests/php-modules.sh
@@ -38,6 +38,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -52,6 +53,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 sysvsem
@@ -107,6 +109,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -121,6 +124,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 sysvsem


### PR DESCRIPTION
- PHP versions 
  - 8.2.30 -> 8.2.31
  - 8.3.30 -> 8.3.31
  - 8.4.17 -> 8.4.21
  - 8.5.2 -> 8.5.6
- Tools
  - gomplate 3.11.3 -> 5.1.0
  - Composer 1.10.27 -> 1.10.28
  - Composer 2.9.3 -> 2.10.0
  - Drush 8.4.12 -> 8.5.0
  - Platform.sh CLI 5.6.0 -> 5.9.0
  - Acquia CLI 2.55.0 -> 2.61.3
  - Terminus 4.1.1 -> 4.3.0
  - yq 4.50.1 -> 4.53.2
  - Node.js 24.13.0 -> 24.16.0
- VS Code Server
  - VS Code Server 4.108.2 -> 4.122.0
  - VS Code GitLens 17.9.0 -> 2026.6.10649
  - VS Code Xdebug 1.40.0 -> 1.40.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft SQL Server driver support in PHP 8.5

* **Chores**
  * Updated PHP base images and runtime versions across all supported versions (8.2–8.5)
  * Updated bundled development tools and extensions including Composer, Drush, Node.js, code-server, and VS Code extensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->