### PR TITLE
Release 3.12.0

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -80,7 +80,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Environment variables
         run: |
@@ -95,14 +95,14 @@ jobs:
           docker info
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         # Build and cache image in the registry
         name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.BUILD_DIR }}
           file: ${{ env.BUILD_DIR }}/Dockerfile
@@ -173,10 +173,10 @@ jobs:
     steps:
       -
         name: Setup Bats
-        uses: bats-core/bats-action@3.0.1
+        uses: bats-core/bats-action@4.0.0
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Environment variables
         run: |
@@ -206,7 +206,7 @@ jobs:
       # Dynamic variable names cannot be used when mapping step outputs to job outputs.
       # Step outputs cannot be accessed directly from other jobs. Dead end.
       - name: Store test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ env.GIT_SHA7 }}-${{ env.VERSION_PREFIX }}${{ env.VERSION }}-${{ env.ARCH }}
           path: ${{ github.workspace }}/test-results-*.txt
@@ -236,7 +236,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Environment variables
         run: |
@@ -247,13 +247,13 @@ jobs:
       -
         # Login to Docker Hub
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Retrieve test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-${{ env.GIT_SHA7 }}-*
           merge-multiple: true

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.2.30-fpm-trixie AS cli
+FROM php:8.2.31-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.3.30-fpm-trixie AS cli
+FROM php:8.3.31-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -162,16 +162,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -251,7 +251,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -340,9 +340,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.4.17-fpm-trixie AS cli
+FROM php:8.4.21-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -148,9 +148,9 @@ RUN set -xe; \
 		ssh2 \
 		xdebug \
 		xhprof \
-		# MSSQL PHP client - not available yet for PHP 8.5 via docker-php-extension-installer
-		# pdo_sqlsrv \
-		# sqlsrv \
+		# MSSQL PHP client
+		pdo_sqlsrv \
+		sqlsrv \
 	;\
 	# Disable xdebug and xhprof by default to avoid performance impact
 	# They can be enabled via environment variables at runtime (XDEBUG_ENABLED=1 and XHPROF_ENABLED=1)

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -87,7 +87,7 @@ RUN set -xe; \
 # TODO: Replace gosu with sudo/su in startup.sh
 ENV \
 	GOSU_VERSION=1.13 \
-	GOMPLATE_VERSION=3.11.3
+	GOMPLATE_VERSION=5.1.0
 RUN set -xe; \
 	# Install gosu and give access to the docker user primary group to use it.
 	# gosu is used instead of sudo to start the main container process (pid 1) in a docker friendly way.
@@ -161,20 +161,16 @@ RUN set -xe; \
 # PHP tools (installed globally)
 ENV \
 	COMPOSER_DEFAULT_VERSION=2 \
-	COMPOSER_VERSION=1.10.27 \
-	COMPOSER2_VERSION=2.9.3 \
-	DRUSH_VERSION=8.4.12 \
+	COMPOSER_VERSION=1.10.28 \
+	COMPOSER2_VERSION=2.10.0 \
+	DRUSH_VERSION=8.5.0 \
 	DRUPAL_CONSOLE_LAUNCHER_VERSION=1.9.7 \
 	WPCLI_VERSION=2.12.0 \
-	PLATFORMSH_CLI_VERSION=5.6.0 \
-	ACQUIA_CLI_VERSION=2.55.0 \
-	# Terminus does not yet support PHP 8.5 officially.
-	# This env var allows running it on newer PHP versions regardless.
-	# https://github.com/pantheon-systems/terminus/issues/2751
-	TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP=1 \
-	TERMINUS_VERSION=4.1.1 \
+	PLATFORMSH_CLI_VERSION=5.9.0 \
+	ACQUIA_CLI_VERSION=2.61.3 \
+	TERMINUS_VERSION=4.3.0 \
 	JQ_VERSION=1.8.1 \
-	YQ_VERSION=4.50.1
+	YQ_VERSION=4.53.2
 RUN set -xe; \
 	# Composer 1.x
 	curl -fsSL "https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar" -o /usr/local/bin/composer1; \
@@ -254,7 +250,7 @@ $HOME/.config/composer/vendor/phpcompatibility/phpcompatibility-paragonie/PHPCom
 # Node.js (installed as user)
 ENV \
 	NVM_VERSION=0.40.4 \
-	NODE_VERSION=24.13.0 \
+	NODE_VERSION=24.16.0 \
 	# yarn v1 (classic) https://github.com/yarnpkg/yarn/releases
 	YARN_VERSION=1.22.22
 # Don't use -x here, as the output may be excessive
@@ -343,9 +339,9 @@ USER docker
 ARG HOME=/home/docker
 
 ENV \
-	CODE_SERVER_VERSION=4.108.2 \
-	VSCODE_GITLENS_VERSION=17.9.0 \
-	VSCODE_XDEBUG_VERSION=1.40.0 \
+	CODE_SERVER_VERSION=4.122.0 \
+	VSCODE_GITLENS_VERSION=2026.6.10649 \
+	VSCODE_XDEBUG_VERSION=1.40.1 \
 	VSCODE_HOME="${HOME}/code-server"
 
 # Install code-server

--- a/8.5/Dockerfile
+++ b/8.5/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv (ignore false positives in ARG/ENV)
 
-FROM php:8.5.2-fpm-trixie AS cli
+FROM php:8.5.6-fpm-trixie AS cli
 
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive

--- a/8.5/tests/php-modules.sh
+++ b/8.5/tests/php-modules.sh
@@ -38,6 +38,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -52,6 +53,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 sysvsem
@@ -107,6 +109,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -121,6 +124,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 ssh2
 standard
 sysvsem

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This image(s) is part of the [Docksal](https://docksal.io) image library.
 ## Versions and image tag naming convention
 
 - Stable image versions
-  - `docksal/cli:php8.2-3.11`, `docksal/cli:php8.2` - PHP 8.2
-  - `docksal/cli:php8.3-3.11`, `docksal/cli:php8.3` - PHP 8.3
-  - `docksal/cli:php8.4-3.11`, `docksal/cli:php8.4` - PHP 8.4
-  - `docksal/cli:php8.5-3.11`, `docksal/cli:php8.5`, `docksal/cli:latest` - PHP 8.5
+  - `docksal/cli:php8.2-3.12`, `docksal/cli:php8.2` - PHP 8.2
+  - `docksal/cli:php8.3-3.12`, `docksal/cli:php8.3` - PHP 8.3
+  - `docksal/cli:php8.4-3.12`, `docksal/cli:php8.4` - PHP 8.4
+  - `docksal/cli:php8.5-3.12`, `docksal/cli:php8.5`, `docksal/cli:latest` - PHP 8.5
 - Development image versions
   - `docksal/cli:php8.2-edge` - PHP 8.2
   - `docksal/cli:php8.3-edge` - PHP 8.3


### PR DESCRIPTION
## Updates

- PHP updates
  - 8.2.31
  - 8.3.31
  - 8.4.21
  - 8.5.6 (now with Microsoft SQL Server driver support)
- Tooling updates
  - gomplate 5.1.0
  - Composer 1.10.28
  - Composer 2.10.0
  - Drush 8.5.0
  - Platform.sh CLI 5.9.0
  - Acquia CLI 2.61.3
  - Terminus 4.3.0
  - yq 4.53.2
  - Node.js 24.16.0 (LTS)
- VS Code Server
  - VS Code Server 4.122.0
  - VS Code GitLens 2026.6.10649
  - VS Code Xdebug 1.40.1
- [CI] GitHub Actions updates

**Full Changelog:** https://github.com/docksal/service-cli/compare/v3.11.0...v3.12.0

## Images

```
docksal/cli:php8.2-3.12
docksal/cli:php8.3-3.12
docksal/cli:php8.4-3.12
docksal/cli:php8.5-3.12
```
